### PR TITLE
tweaks transfer train hijack announcements, tweaks some shuttles

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -36,6 +36,10 @@
 /obj/structure/table/halflife/no_smooth/metal,
 /turf/open/floor/plating/indoor/grooved,
 /area/shuttle/arrival)
+"w" = (
+/obj/structure/window/fulltile,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/arrival)
 "x" = (
 /obj/docking_port/mobile/arrivals{
 	dir = 2;
@@ -91,13 +95,13 @@
 H
 m
 m
-m
+w
 m
 m
 s
 m
 m
-m
+w
 m
 m
 B
@@ -155,13 +159,13 @@ J
 H
 m
 m
-m
+w
 m
 m
 s
 m
 m
-m
+w
 m
 m
 B

--- a/_maps/shuttles/cargo_box.dmm
+++ b/_maps/shuttles/cargo_box.dmm
@@ -9,6 +9,7 @@
 /obj/machinery/door/unpowered/halflife/metal{
 	dir = 8
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/supply)
 "i" = (
@@ -16,6 +17,7 @@
 /obj/machinery/door/unpowered/halflife/metal{
 	dir = 8
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/supply)
 "j" = (

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -16,7 +16,7 @@
 "cU" = (
 /obj/docking_port/mobile/emergency{
 	dir = 2;
-	name = "Box emergency shuttle"
+	name = "Transfer Train"
 	},
 /turf/closed/wall/halflife/metal,
 /area/shuttle/escape)
@@ -95,9 +95,7 @@
 /turf/open/floor/plating/indoor/grooved,
 /area/shuttle/escape)
 "GQ" = (
-/obj/structure/table/halflife/no_smooth/large/metal/desk{
-	dir = 8
-	},
+/obj/structure/table/halflife/metal,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "Hg" = (
@@ -281,7 +279,7 @@ Vv
 gn
 fK
 lJ
-HH
+GQ
 GQ
 lJ
 bi

--- a/_maps/shuttles/ferry_fancy.dmm
+++ b/_maps/shuttles/ferry_fancy.dmm
@@ -9,7 +9,7 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/transport)
 "e" = (
-/obj/machinery/power/shuttle_engine/propulsion/left{
+/obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
@@ -19,11 +19,11 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/transport)
 "i" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/computer/crew,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/transport)
 "k" = (
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/transport)
 "l" = (
@@ -33,6 +33,7 @@
 /obj/machinery/computer/shuttle/ferry/request{
 	dir = 8
 	},
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/transport)
 "n" = (
@@ -45,12 +46,22 @@
 	},
 /turf/closed/wall/halflife/metal,
 /area/shuttle/transport)
+"o" = (
+/obj/machinery/turnstile/brig/halflife/forcefield{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/combine,
+/area/shuttle/transport)
 "r" = (
 /turf/closed/wall/halflife/metal,
 /area/shuttle/transport)
 "H" = (
 /obj/machinery/door/airlock/highsecurity/combine,
 /obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/shuttle/transport)
+"L" = (
+/obj/machinery/computer/security,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/transport)
 
@@ -112,17 +123,17 @@ H
 "}
 (9,1,1) = {"
 r
-l
-l
-i
+r
+o
+r
 r
 "}
 (10,1,1) = {"
-H
+r
+L
 l
-l
-l
-H
+i
+r
 "}
 (11,1,1) = {"
 r

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -193,10 +193,10 @@
 					to_chat(usr, span_warning("You've already escaped. Never going back to that place again!"))
 					return
 				if (SHUTTLE_CONSOLE_RECHARGING)
-					to_chat(usr, span_warning("Shuttle engines are not ready for use."))
+					to_chat(usr, span_warning("Engines are not ready for use."))
 					return
 				if (SHUTTLE_CONSOLE_INTRANSIT)
-					to_chat(usr, span_warning("Shuttle already in transit."))
+					to_chat(usr, span_warning("Train already in transit."))
 					return
 				if (SHUTTLE_CONSOLE_DESTINVALID)
 					to_chat(usr, span_warning("Invalid destination."))
@@ -213,10 +213,10 @@
 				return TRUE
 		if("request")
 			if(!COOLDOWN_FINISHED(src, request_cooldown))
-				to_chat(usr, span_warning("CentCom is still processing last authorization request!"))
+				to_chat(usr, span_warning("Overwatch is still processing last authorization request!"))
 				return
 			COOLDOWN_START(src, request_cooldown, 1 MINUTES)
-			to_chat(usr, span_notice("Your request has been received by CentCom."))
+			to_chat(usr, span_notice("Your request has been received by Overwatch."))
 			to_chat(GLOB.admins, "<b>SHUTTLE: <font color='#3d5bc3'>[ADMIN_LOOKUPFLW(usr)] (<A HREF='?_src_=holder;[HrefToken()];move_shuttle=[shuttleId]'>Move Shuttle</a>)(<A HREF='?_src_=holder;[HrefToken()];unlock_shuttle=[REF(src)]'>Lock/Unlock Shuttle</a>)</b> is requesting to move or unlock the shuttle.</font>")
 			return TRUE
 

--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -1,6 +1,6 @@
 /obj/machinery/computer/shuttle/ferry
-	name = "transport ferry console"
-	desc = "A console that controls the transport ferry."
+	name = "overwatch transport train console"
+	desc = "A console that controls the Overwatch transport train."
 	circuit = /obj/item/circuitboard/computer/ferry
 	shuttleId = "ferry"
 	possible_destinations = "ferry_home;ferry_away"
@@ -21,7 +21,7 @@
 	return allow_silicons ? ..() : FALSE
 
 /obj/machinery/computer/shuttle/ferry/request
-	name = "ferry console"
+	name = "overwatch transport train console"
 	circuit = /obj/item/circuitboard/computer/ferry/request
 	possible_destinations = "ferry_home;ferry_away"
 	req_access = list(ACCESS_CENT_GENERAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- changes transfer train hijack announcements to make sense (you're moving track switches, not TELEPORTING TO SIBERIA)
- changes the transfer train backroom table to one that doesnt pixelshift itself to an OBSCENE degree in transit
- theoretically fixes funky transfer train rotation
- puts a secure bridge in the OTA/ERT train
- puts windows on the arrivals train

## Why It's Good For The Game

lets people see glorious hyperdirt, gives the OTA train a secure area for overwatch nerds to hide in

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: transfer train hijack now makes sense
add: some shuttles have been updated too
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
