### PR TITLE
New method of loading crossbow and bandit changes

### DIFF
--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -427,9 +427,9 @@
 	else if(FACTION_PIRATE in ransomee.faction) //can't ransom your fellow pirates to CentCom!
 		return 0
 	else if(HAS_TRAIT(ransomee, TRAIT_HIGH_VALUE_RANSOM))
-		return 2500 //hl13 edit
+		return 1000 //hl13 edit
 	else
-		return 500 //hl13 edit
+		return 200 //hl13 edit
 
 /datum/export/pirate/ransom/sell_object(mob/living/carbon/human/sold_item, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
 	. = ..()

--- a/code/modules/jobs/job_types/outlands_jobs/combine/ordinal.dm
+++ b/code/modules/jobs/job_types/outlands_jobs/combine/ordinal.dm
@@ -19,6 +19,8 @@
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_STATION_ENGINEER
 
+	mind_traits = list(HEAD_OF_STAFF_MIND_TRAITS)
+
 	job_flags = JOB_EQUIP_RANK|JOB_NEW_PLAYER_JOINABLE|JOB_REOPEN_ON_ROUNDSTART_LOSS|JOB_ASSIGN_QUIRKS|JOB_OUTLANDS_JOB
 
 	departments_list = list(

--- a/code/modules/jobs/job_types/outlands_jobs/rebels/lieutenant.dm
+++ b/code/modules/jobs/job_types/outlands_jobs/rebels/lieutenant.dm
@@ -17,6 +17,8 @@
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_CAPTAIN
 
+	mind_traits = list(HEAD_OF_STAFF_MIND_TRAITS)
+
 	job_flags = JOB_EQUIP_RANK|JOB_NEW_PLAYER_JOINABLE|JOB_REOPEN_ON_ROUNDSTART_LOSS|JOB_ASSIGN_QUIRKS|JOB_OUTLANDS_JOB
 
 	departments_list = list(

--- a/code/modules/jobs/job_types/outlands_jobs/rebels/quartermaster.dm
+++ b/code/modules/jobs/job_types/outlands_jobs/rebels/quartermaster.dm
@@ -17,6 +17,8 @@
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_QUARTERMASTER
 
+	mind_traits = list(HEAD_OF_STAFF_MIND_TRAITS)
+
 	job_flags = JOB_EQUIP_RANK|JOB_NEW_PLAYER_JOINABLE|JOB_REOPEN_ON_ROUNDSTART_LOSS|JOB_ASSIGN_QUIRKS|JOB_OUTLANDS_JOB
 
 	departments_list = list(

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -257,6 +257,31 @@
 		return FALSE
 	return ..()
 
+/obj/item/gun/ballistic/rifle/rebarxbow/attackby(obj/item/A, mob/living/user, params) //hl13 edit, able to load a crossbow thats already drawn
+	. = ..()
+	if (!bolt_locked && chambered == null)
+		chamber_round()
+		A.update_appearance()
+		update_appearance()
+
+		var/protected = FALSE
+
+		if(ishuman(user))
+			var/mob/living/carbon/human/U = user
+			if(U.gloves)
+				var/obj/item/clothing/gloves/electrician_gloves = U.gloves
+				if(electrician_gloves.max_heat_protection_temperature && electrician_gloves.max_heat_protection_temperature > 360)
+					protected = TRUE
+			var/protection = U.get_thermal_protection()
+			if(protection > 360)
+				protected = TRUE
+
+		if(!protected && !HAS_TRAIT(user, TRAIT_RESISTHEAT) && !HAS_TRAIT(user, TRAIT_RESISTHEATHANDS))
+			user.apply_damage(15, BURN, user.get_active_hand(), wound_bonus = CANT_WOUND) //yeowch
+			to_chat(user, span_userdanger("You burn your hand loading the crossbow as the bolt instantly heats up! Wear protective gear or load the bolt first!"))
+			INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, emote), "scream")
+			playsound(user, SFX_SEAR, 50, TRUE)
+
 /obj/item/gun/ballistic/rifle/rebarxbow/shoot_with_empty_chamber(mob/living/user)
 	if(chambered || !magazine || !length(magazine.contents))
 		return ..()


### PR DESCRIPTION
bandits earn less money from kidnapping people, heads from both modes ARE SUPPOSED to reach their goal but i couldnt get it working in testing even with the ones that should already work, and 5 regular players will acheive their goal, like how it used to be before the value was decreased from 2500 to 1000

crossbow can be drawn before loading a rod, but also if you dont have any protection it'll burn you since your hand is in direct contact with red hot metal