### PR TITLE
High-Security Sector / Permanent Residence Cell Block

### DIFF
--- a/_maps/map_files/city13_prison/city13_prison.dmm
+++ b/_maps/map_files/city13_prison/city13_prison.dmm
@@ -3,10 +3,21 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands/shop)
+"ab" = (
+/obj/machinery/button/door/directional/east,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "ac" = (
 /obj/structure/halflife/rug/rubber,
 /turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security)
+"ae" = (
+/obj/item/clothing/suit/armor/vest/press{
+	name = "United Nations armor vest";
+	desc = "A blue armor vest used to distinguish non-combatant \PEACEKEEPER\ UN members, though this is only bound to put a bigger target on your back nowadays."
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "af" = (
 /obj/structure/closet/halflife,
 /obj/item/card/id/advanced/halflife/grey,
@@ -108,6 +119,10 @@
 "av" = (
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/maintenance)
+"ax" = (
+/obj/item/target,
+/turf/open/floor/plating/indoor/metal/grate/border,
+/area/halflife/indoors/prison/maintenance)
 "ay" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/indoor/woodc/fancy,
@@ -129,6 +144,27 @@
 	},
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/infirmary)
+"aC" = (
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 8
+	},
+/obj/structure/railing/halflife/full{
+	dir = 8
+	},
+/obj/structure/railing/halflife/full{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "aD" = (
 /obj/structure/table/halflife/wood/constructed/cobbled,
 /obj/effect/spawner/random/halflife/loot/ammo,
@@ -161,6 +197,10 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/prison/mining)
+"aL" = (
+/mob/living/basic/halflife/zombie/fast,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "aM" = (
 /obj/structure/sign/poster/halflife/combine/three{
 	pixel_y = 32
@@ -454,6 +494,9 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/maintenance)
+"bX" = (
+/turf/open/floor/plating,
+/area/halflife/indoors/prison)
 "bZ" = (
 /obj/machinery/door/unpowered/halflife/metal{
 	keylock = 1;
@@ -514,6 +557,14 @@
 	},
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security/solitary)
+"co" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/innards,
+/obj/structure/closet/secure_closet/freezer/halflife,
+/obj/effect/spawner/random/halflife/loot/uncommon,
+/obj/effect/spawner/random/halflife/loot/fridge_goods,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "cr" = (
 /obj/machinery/telecomms/server/presets/common/birdstation,
 /turf/open/floor/plating/indoor/metal/combine,
@@ -524,6 +575,10 @@
 	},
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/bunker)
+"ct" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/halflife/indoors/prison/maintenance)
 "cv" = (
 /obj/machinery/photocopier/gratis,
 /turf/open/floor/plating/indoor/concrete,
@@ -538,6 +593,10 @@
 	},
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/halflife/indoors/prison/cargo)
+"cy" = (
+/obj/structure/rack,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "cz" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating/indoor/metal/plate,
@@ -546,6 +605,9 @@
 /obj/effect/spawner/random/halflife/loot/trash,
 /turf/open/misc/beach/sand,
 /area/halflife/outdoors/forest)
+"cB" = (
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/halflife/indoors/prison)
 "cC" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Freezer Lower";
@@ -610,10 +672,18 @@
 	},
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"cT" = (
+/obj/effect/decal/cleanable/food/plant_smudge,
+/turf/open/floor/plating/indoor/woodc/mosaic,
+/area/halflife/indoors/prison)
 "cU" = (
 /obj/structure/halflife/fence/wire/barb,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"cW" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "cY" = (
 /obj/machinery/turnstile/brig/halflife/forcefield/curfew{
 	dir = 1
@@ -674,10 +744,21 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/plating/indoor/metal/grate/border/warning,
 /area/halflife/indoors/prison/factory)
+"dq" = (
+/obj/structure/halflife/trash/garbage/dumpster/crate,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "dr" = (
 /obj/effect/landmark/navigate_destination/halflife/mines,
 /turf/open/floor/plating/indoor/checkered,
 /area/halflife/indoors/prison/cells)
+"ds" = (
+/obj/machinery/conveyor/auto,
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Motorway B"
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "dt" = (
 /obj/structure/table/halflife/no_smooth/wood/stand,
 /turf/open/floor/plating/indoor/tile/green,
@@ -686,6 +767,11 @@
 /obj/structure/bed/medical,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/infirmary)
+"dv" = (
+/obj/effect/decal/cleanable/blood/trails,
+/obj/effect/decal/cleanable/blood/trails,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "dw" = (
 /obj/structure/table/halflife/no_smooth/large/wood/desk,
 /turf/open/floor/plating/indoor/tile/navy,
@@ -697,14 +783,10 @@
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/maintenance)
 "dy" = (
-/obj/machinery/door/unpowered/halflife/metal/red{
-	dir = 8;
-	keylock = 1;
-	locked = 1;
-	lockid = "maint"
-	},
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison)
+/obj/machinery/door/airlock/highsecurity/combine,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "dz" = (
 /obj/structure/closet/halflife,
 /obj/machinery/light/small/directional/south,
@@ -748,19 +830,31 @@
 /obj/effect/mob_spawn/corpse/human/citizen,
 /turf/open/floor/plating/indoor/concrete/sewer,
 /area/halflife/indoors/sewer)
+"dI" = (
+/obj/structure/railing/halflife/full{
+	dir = 6
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison)
 "dJ" = (
 /obj/structure/bed/halflife/bedframe/wood,
 /obj/structure/bed/halflife/mattress/stale,
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/laborunion)
-"dN" = (
-/obj/machinery/door/unpowered/halflife/metal/red{
-	keylock = 1;
-	locked = 1;
-	dir = 4
+"dL" = (
+/obj/structure/halflife/stationclock{
+	desc = "A clock ticking down the time until your freedom. It doesn't seem to be moving."
 	},
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison)
+"dM" = (
+/obj/machinery/turnstile/brig/halflife/forcefield/curfew,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/halflife/indoors/prison)
+"dN" = (
+/obj/structure/rack,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security/solitary)
 "dO" = (
 /obj/structure/halflife/rug/yellow,
 /obj/structure/chair/office/halflife/blue{
@@ -821,6 +915,12 @@
 /obj/structure/halflife/trash_decal,
 /turf/open/floor/plating/indoor/cafeteria,
 /area/halflife/indoors/prison/cafeteria)
+"dZ" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Inner Security Hall"
+	},
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "ea" = (
 /obj/machinery/watermixer,
 /turf/open/floor/plating/indoor/metal/industrial,
@@ -884,6 +984,9 @@
 	},
 /turf/open/floor/plating/indoor/tiled9,
 /area/halflife/indoors/prison/infirmary)
+"em" = (
+/turf/open/floor/plating/indoor/checkered,
+/area/halflife/indoors/prison)
 "en" = (
 /obj/structure/table/halflife/wood/constructed/cobbled,
 /obj/structure/rustic_extractor,
@@ -1034,6 +1137,12 @@
 /obj/structure/stairs/halflife/concrete,
 /turf/open/floor/plating/indoor/tile,
 /area/halflife/indoors/prison)
+"fb" = (
+/obj/structure/table/halflife/wood/constructed,
+/obj/item/reagent_containers/cup/watering_can/wood,
+/obj/item/reagent_containers/spray/pestspray,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/halflife/indoors/prison)
 "fc" = (
 /obj/structure/halflife/sign/combine/prison,
 /turf/open/floor/plating/ground/dirt,
@@ -1146,6 +1255,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/security/warden)
+"fA" = (
+/obj/structure/halflife/road_barrier/concrete/alt{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/halflife/indoors/prison)
 "fB" = (
 /turf/open/floor/plating/indoor/metal/pipe,
 /area/halflife/indoors/bunker)
@@ -1164,6 +1279,12 @@
 /obj/structure/halflife/trash/garbage/dumpster,
 /turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison/factory)
+"fG" = (
+/obj/item/instrument/harmonica,
+/obj/structure/rack,
+/obj/item/instrument/recorder,
+/turf/open/floor/plating/indoor/woodc,
+/area/halflife/indoors/prison)
 "fH" = (
 /obj/structure/railing/halflife/solo{
 	dir = 4
@@ -1173,6 +1294,11 @@
 "fI" = (
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cells)
+"fJ" = (
+/obj/structure/reagent_dispensers/servingdish,
+/obj/structure/table/halflife/metal,
+/turf/open/floor/plating/indoor/tile/navy,
+/area/halflife/indoors/prison)
 "fK" = (
 /obj/machinery/light/small/cyan/directional/north,
 /obj/structure/table/halflife/metal/grate,
@@ -1207,8 +1333,8 @@
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison)
 "fR" = (
-/obj/machinery/door/airlock/highsecurity/combine,
-/turf/open/floor/plating/indoor/checkered,
+/obj/machinery/door/unpowered/halflife/seethrough/fence/wire,
+/turf/open/floor/plating/indoor/tile,
 /area/halflife/indoors/prison/cells)
 "fU" = (
 /obj/structure/table/halflife/metal/heavy,
@@ -1243,6 +1369,15 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/engineering)
+"gc" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/halflife/indoors/prison)
+"gd" = (
+/obj/structure/fluff/wallsign/directional/south,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "ge" = (
 /obj/effect/mob_spawn/corpse/zombie,
 /turf/open/floor/plating/ground/dirt,
@@ -1312,6 +1447,9 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison)
+"gv" = (
+/turf/open/floor/plating/ground/sidewalk/inner/slums,
+/area/halflife/indoors/prison)
 "gw" = (
 /obj/structure/halflife/fence/wire/barb,
 /turf/open/floor/plating/ground/dirt,
@@ -1356,6 +1494,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security/armory)
+"gI" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "gJ" = (
 /obj/item/hl13_small_flag/poland,
 /turf/open/floor/plating/indoor/woodc/mosaic,
@@ -1382,10 +1526,20 @@
 	},
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
+"gP" = (
+/obj/structure/sign/warning/biohazard/directional/east,
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "gR" = (
 /obj/structure/flora/tree/halflife/pine/style_random,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"gS" = (
+/obj/item/reagent_containers/cup/soda_cans/breenwater/fuel,
+/obj/structure/halflife/road_barrier/concrete,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "gT" = (
 /obj/machinery/door/unpowered/halflife/wood/white{
 	keylock = 1;
@@ -1398,6 +1552,12 @@
 /obj/structure/halflife/rug/fancy,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/prison/security/warden)
+"gW" = (
+/obj/structure/table/halflife/metal/small,
+/obj/item/reagent_containers/cup/soda_cans/breenwater/purple/protein,
+/obj/machinery/light/small/blacklight/directional/north,
+/turf/open/floor/plating/indoor/concrete,
+/area/halflife/indoors/prison)
 "gX" = (
 /obj/machinery/computer/records/security,
 /turf/open/floor/plating/indoor/metal/combine,
@@ -1530,6 +1690,12 @@
 /obj/structure/chair/halflife/metal/folding,
 /turf/open/floor/plating/ground/rockunder,
 /area/halflife/indoors/sewer/cave)
+"hD" = (
+/obj/structure/halflife/road_barrier{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
 "hE" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/indoor/woodc/mosaic,
@@ -1547,6 +1713,10 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
+"hI" = (
+/obj/structure/weightmachine,
+/turf/open/floor/plating/indoor/concrete/bricks,
+/area/halflife/indoors/prison)
 "hJ" = (
 /obj/machinery/door/unpowered/halflife/seethrough/grate,
 /turf/open/floor/plating/indoor/tile/black,
@@ -1605,6 +1775,11 @@
 "hW" = (
 /turf/open/floor/plating/indoor/metal/walkway,
 /area/halflife/outdoors/forest)
+"hX" = (
+/obj/machinery/shower/directional/east,
+/obj/item/soap/deluxe,
+/turf/open/floor/plating/ground/sidewalk/inner/slums,
+/area/halflife/indoors/prison)
 "hY" = (
 /obj/structure/table/halflife/no_smooth/large/wood/desk,
 /obj/effect/spawner/random/halflife/loot,
@@ -1659,6 +1834,10 @@
 	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/entrance)
+"im" = (
+/obj/structure/halflife/trash/books/pile,
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/halflife/indoors/prison/security)
 "in" = (
 /obj/structure/closet/crate/halflife/ration_supplies,
 /turf/open/floor/plating/indoor/concrete,
@@ -1674,9 +1853,18 @@
 /mob/living/basic/halflife/headcrab,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"iu" = (
+/obj/structure/fluff/wallsign/directional/north,
+/turf/closed/wall/halflife/metal,
+/area/halflife/indoors/prison/security)
 "iw" = (
 /turf/closed/indestructible/rock,
 /area/halflife/indoors/sewer/outlandscave)
+"ix" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/structure/halflife/trash/garbage,
+/turf/open/floor/plating/indoor/concrete,
+/area/halflife/indoors/prison)
 "iy" = (
 /obj/machinery/vending/gifts,
 /turf/open/floor/plating/indoor/woodc/wide,
@@ -1722,6 +1910,12 @@
 /obj/structure/halflife/pipes/vent,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/bunker)
+"iK" = (
+/obj/structure/chair/halflife/metal/blue{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "iL" = (
 /obj/effect/spawner/random/halflife/loot,
 /turf/open/floor/plating/ground/rockunder,
@@ -1801,11 +1995,16 @@
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/infirmary)
 "je" = (
-/obj/structure/halflife/pipes/horizontal/end{
-	dir = 1
+/obj/structure/halflife/trash/bricks,
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/halflife/indoors/prison/security)
+"jf" = (
+/obj/structure/closet/secure_closet/halflife,
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Transfer Room"
 	},
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "jg" = (
 /obj/structure/table/halflife/metal/alt,
 /obj/item/storage/box/bodybags,
@@ -1938,8 +2137,8 @@
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/sewer)
 "jL" = (
-/obj/machinery/door/unpowered/halflife/seethrough/fence/wire,
-/turf/open/floor/plating/indoor/tile,
+/obj/item/hl13_small_flag/combine,
+/turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison)
 "jM" = (
 /obj/machinery/stalker_chamber,
@@ -2000,6 +2199,9 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plating/indoor/tiled9,
 /area/halflife/indoors/prison/infirmary)
+"ke" = (
+/turf/open/floor/plating/indoor/metal/grate/border,
+/area/halflife/indoors/prison)
 "kf" = (
 /obj/structure/window/fulltile/halflife/nosmooth/reinforced{
 	dir = 4
@@ -2054,10 +2256,26 @@
 	},
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/security)
+"kq" = (
+/obj/structure/curtain/bounty/start_closed,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "kr" = (
 /obj/machinery/door/unpowered/halflife/metal,
 /turf/open/floor/plating/indoor/metal/grate,
 /area/halflife/indoors/sewer)
+"kt" = (
+/obj/machinery/door/poddoor/shutters/window{
+	id = "visitation_gate"
+	},
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
+"ku" = (
+/obj/structure/table/halflife/wood/constructed/cobbled,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/mop,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "kv" = (
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/outdoors/forest)
@@ -2089,9 +2307,18 @@
 "kD" = (
 /turf/closed/wall/halflife/metal,
 /area/halflife/indoors/prison/security)
+"kE" = (
+/obj/item/stack/sheet/scrap_metal,
+/obj/structure/barricade/wooden/solid,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "kG" = (
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest/prison_yard)
+"kH" = (
+/obj/item/cultivator/rake,
+/turf/open/floor/plating/indoor/woodc/mosaic,
+/area/halflife/indoors/prison)
 "kI" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plating/indoor/woodc/fancy,
@@ -2138,6 +2365,12 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison)
+"kT" = (
+/obj/structure/closet/crate/halflife,
+/obj/item/soap,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "kU" = (
 /obj/structure/halflife/trash/papers/three{
 	dir = 8;
@@ -2152,6 +2385,10 @@
 	},
 /turf/closed/wall/halflife/concrete/bunker,
 /area/halflife/indoors/prison)
+"kW" = (
+/obj/structure/halflife/trash/food/misc,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/halflife/indoors/prison/maintenance)
 "kX" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/indoor/woodc/fancy,
@@ -2165,6 +2402,9 @@
 /obj/structure/halflife/pallet/stack,
 /turf/open/floor/plating/indoor/concrete/sewer,
 /area/halflife/indoors/sewer)
+"lb" = (
+/turf/open/floor/plating/indoor/woodc/mosaic,
+/area/halflife/indoors/prison)
 "lc" = (
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/prison/commissary)
@@ -2296,9 +2536,8 @@
 /turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison/factory)
 "lD" = (
-/obj/structure/table/halflife/wood,
-/obj/structure/halflife/trash/papers/three,
-/turf/open/floor/plating/indoor/tile,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/tile/navy,
 /area/halflife/indoors/prison)
 "lF" = (
 /turf/open/floor/plating/indoor/metal/combine,
@@ -2326,6 +2565,10 @@
 /obj/structure/table/halflife/metal/grate,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/gym)
+"lL" = (
+/obj/machinery/conveyor/auto,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "lM" = (
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/halflife/indoors/prison/cargo)
@@ -2352,6 +2595,12 @@
 "lT" = (
 /turf/open/floor/plating/indoor/metal/pipe,
 /area/halflife/indoors/sewer)
+"lU" = (
+/obj/structure/halflife/road_barrier/concrete{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/halflife/indoors/prison)
 "lV" = (
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/prison/commissary)
@@ -2391,9 +2640,11 @@
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/mining)
 "me" = (
-/obj/structure/chair/halflife/metal/stool,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "mf" = (
 /obj/effect/spawner/random/halflife/loot/consumables,
 /turf/open/floor/plating/indoor/woodc/wide,
@@ -2410,6 +2661,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/outlands/shop)
+"mj" = (
+/obj/structure/mannequin,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "mk" = (
 /obj/structure/halflife/trash/papers/three,
 /turf/open/floor/plating/indoor/woodc,
@@ -2519,6 +2774,13 @@
 /obj/effect/spawner/random/halflife/loot/uncommon,
 /turf/open/floor/plating/indoor/metal/pipe,
 /area/halflife/indoors/sewer)
+"mG" = (
+/obj/structure/closet/crate/halflife{
+	name = "footlocker";
+	desc = "A rectangular steel locker, traditionally mounted at the end of beds."
+	},
+/turf/open/floor/plating/indoor/grooved2,
+/area/halflife/indoors/prison)
 "mH" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/halflife/loot/trash,
@@ -2537,6 +2799,16 @@
 /obj/effect/spawner/random/halflife/loot,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/bunker)
+"mL" = (
+/obj/structure/fluff/wallsign/directional/south,
+/turf/closed/wall/halflife/metal,
+/area/halflife/indoors/prison/security)
+"mM" = (
+/obj/structure/window/fulltile/halflife/nosmooth/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "mN" = (
 /obj/structure/ladder/halflife,
 /turf/open/floor/plating/indoor/metal/plate,
@@ -2586,6 +2858,13 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/plating/indoor/metal,
 /area/halflife/outdoors/forest)
+"mY" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "mZ" = (
 /obj/structure/table/halflife/no_smooth/large/crafting/tinkerbench,
 /turf/open/floor/plating/indoor/metal/industrial,
@@ -2667,6 +2946,12 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cells)
+"nq" = (
+/obj/structure/chair/halflife/metal/stool{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/carpet,
+/area/halflife/indoors/prison/maintenance)
 "nr" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/plating/ground/rockunder,
@@ -2682,6 +2967,12 @@
 	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/sewer)
+"nv" = (
+/obj/effect/decal/cleanable/blood/trails,
+/obj/effect/decal/cleanable/blood/trails,
+/obj/structure/halflife/tv/wooden,
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "nw" = (
 /obj/effect/spawner/random/halflife/loot/crafting_bench,
 /turf/open/floor/plating/ground/dirt,
@@ -2727,6 +3018,10 @@
 "nH" = (
 /turf/open/openspace,
 /area/halflife/indoors/prison/security)
+"nI" = (
+/obj/structure/dresser,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "nJ" = (
 /obj/structure/closet/halflife/wall/firstaid,
 /obj/effect/spawner/random/halflife/loot/heal,
@@ -2756,6 +3051,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest)
+"nQ" = (
+/obj/item/storage/box/halflife/ration/worstration,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "nR" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/plating/indoor/metal/combine,
@@ -2786,6 +3085,10 @@
 	},
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/security/warden)
+"nX" = (
+/obj/structure/punching_bag,
+/turf/open/floor/plating,
+/area/halflife/indoors/prison)
 "nY" = (
 /obj/structure/stairs/halflife/concrete{
 	dir = 8
@@ -2830,6 +3133,10 @@
 /obj/machinery/telecomms/bus/preset_one/birdstation,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/dispatch)
+"oi" = (
+/obj/structure/broken_flooring/pile/directional/west,
+/turf/open/floor/plating/indoor/woodc/mosaic,
+/area/halflife/indoors/prison)
 "oj" = (
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison)
@@ -2861,6 +3168,10 @@
 /obj/effect/spawner/random/halflife/loot,
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/outlands/shop)
+"on" = (
+/obj/structure/halflife/trash/garbage,
+/turf/open/floor/plating/indoor/metal/grate/border,
+/area/halflife/indoors/prison)
 "oo" = (
 /obj/machinery/door/unpowered/halflife/metal,
 /turf/open/floor/plating/indoor/concrete/small,
@@ -2986,6 +3297,15 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/engineering)
+"oN" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security-To-High-Sec Transfer Lobby"
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "oO" = (
 /obj/structure/railing/halflife/sewer,
 /turf/open/halflife/water/sewer/shallow,
@@ -3047,10 +3367,26 @@
 /turf/open/floor/plating/indoor/tile/kitchen,
 /area/halflife/indoors/prison/cafeteria)
 "pb" = (
-/obj/structure/table/halflife/no_smooth/dice,
-/obj/item/toy/cards/deck,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
+	dir = 8
+	},
+/obj/structure/railing/halflife/full{
+	dir = 4
+	},
+/obj/structure/railing/halflife/full{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "pc" = (
 /obj/structure/halflife/trash/wood{
 	dir = 1
@@ -3106,6 +3442,14 @@
 /obj/structure/halflife/trash/glass/plate,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"pn" = (
+/obj/structure/filingcabinet/hl2,
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Gate Control"
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "po" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating/indoor/tile/black,
@@ -3140,6 +3484,18 @@
 	},
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/outlands/shop)
+"pw" = (
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/halflife/indoors/prison/maintenance)
+"px" = (
+/obj/structure/railing/halflife/full{
+	dir = 5
+	},
+/obj/structure/railing/halflife/full{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "pA" = (
 /obj/machinery/combine_walllight/directional/south,
 /turf/open/floor/plating/indoor/metal/combine,
@@ -3180,6 +3536,9 @@
 /obj/machinery/stalker_chamber,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/dispatch)
+"pI" = (
+/turf/open/floor/plating/indoor/woodc,
+/area/halflife/indoors/prison)
 "pJ" = (
 /obj/structure/table/halflife/metal/heavy,
 /obj/machinery/light/small/directional/south,
@@ -3191,10 +3550,10 @@
 /turf/open/floor/plating/ground/rockunder,
 /area/halflife/indoors/sewer/outlandscave)
 "pL" = (
-/obj/structure/table/halflife/no_smooth/cable_reel,
-/obj/effect/spawner/random/halflife/loot/alcohol,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/table/halflife/wood,
+/obj/item/radio/intercom,
+/turf/open/floor/plating/indoor/tile,
+/area/halflife/indoors/prison)
 "pM" = (
 /obj/structure/halflife/barrel/quadruple/grey,
 /turf/open/floor/plating/indoor/tile/black,
@@ -3208,6 +3567,18 @@
 	dir = 1
 	},
 /turf/open/floor/plating/indoor/concrete,
+/area/halflife/indoors/prison)
+"pP" = (
+/obj/structure/sign/flag/terragov{
+	name = "flag of the United Nations";
+	desc = "The flag of a dream lost long ago. Looks like someone was hoping for a return, as many of these types of flags have been torn up."
+	},
+/turf/closed/wall/halflife/concrete/bunker,
+/area/halflife/indoors/prison/maintenance)
+"pQ" = (
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/plating/indoor/carpet/shaggy,
 /area/halflife/indoors/prison)
 "pR" = (
 /turf/open/floor/plating/ground/sidewalk/cobblestone,
@@ -3243,14 +3614,12 @@
 /obj/item/storage/halflife/hand_box/cookie,
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/laborunion)
+"pZ" = (
+/obj/machinery/combine_walllight/directional/west,
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/halflife/indoors/prison/security)
 "qa" = (
-/obj/structure/table/halflife/wood,
-/obj/structure/halflife/trash/cardboard{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/turf/open/floor/plating/indoor/tile,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison)
 "qc" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -3337,6 +3706,10 @@
 /obj/structure/bed/halflife/mattress/yellowed,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/outdoors/forest)
+"qs" = (
+/obj/structure/chair/office/halflife/green,
+/turf/open/floor/plating/indoor/concrete/bricks,
+/area/halflife/indoors/prison)
 "qt" = (
 /obj/effect/spawner/random/halflife/plant_spawner,
 /turf/open/floor/plating/ground/dirt,
@@ -3389,6 +3762,13 @@
 	},
 /turf/open/floor/plating/indoor/grooved2,
 /area/halflife/indoors/prison/cells)
+"qE" = (
+/obj/machinery/door/window/brigdoor/security/holding/left/directional/south{
+	dir = 4
+	},
+/obj/structure/table/halflife/metal/heavy,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "qG" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -3463,6 +3843,10 @@
 "qU" = (
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/engineering)
+"qV" = (
+/obj/structure/chair/halflife/metal/stool,
+/turf/open/floor/plating/indoor/checkered,
+/area/halflife/indoors/prison)
 "qW" = (
 /turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security)
@@ -3504,6 +3888,13 @@
 /obj/item/storage/box/halflife/ration/badration,
 /turf/open/floor/plating/indoor/metal/grate,
 /area/halflife/indoors/prison)
+"rd" = (
+/obj/item/stack/bulletcasings,
+/obj/structure/railing/halflife/solo{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/grate/border,
+/area/halflife/indoors/prison/maintenance)
 "re" = (
 /obj/machinery/door/unpowered/halflife/wood,
 /turf/open/floor/plating/indoor/metal/plate,
@@ -3517,6 +3908,10 @@
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"rk" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/ground/dirt,
+/area/halflife/indoors/prison)
 "rl" = (
 /obj/machinery/light/small/cyan/directional/east,
 /turf/open/floor/plating/indoor/sterilesquares,
@@ -3548,6 +3943,11 @@
 /obj/structure/table/halflife/no_smooth/metal,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/infirmary)
+"rp" = (
+/obj/structure/broken_flooring/singular,
+/obj/structure/halflife/road_barrier,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/halflife/indoors/prison)
 "rq" = (
 /obj/structure/closet/halflife,
 /obj/effect/spawner/random/halflife/loot,
@@ -3656,6 +4056,14 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands)
+"rP" = (
+/obj/machinery/door/unpowered/halflife/metal/red{
+	dir = 8;
+	keylock = 1;
+	lockid = "maint"
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "rQ" = (
 /turf/closed/wall/halflife/concrete/bunker,
 /area/halflife/indoors/prison/factory)
@@ -3707,6 +4115,13 @@
 /obj/structure/halflife/rug,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/security/warden)
+"sa" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/machinery/combine_walllight/directional/west,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "sb" = (
 /obj/structure/table/halflife/metal/grate,
 /obj/item/stamp{
@@ -3730,8 +4145,9 @@
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/sewer)
 "se" = (
-/obj/machinery/light/broken/directional/north,
-/turf/open/floor/plating/indoor/tile/black,
+/obj/machinery/washing_machine,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison)
 "sf" = (
 /obj/structure/sign/poster/halflife/combine/three{
@@ -3775,6 +4191,11 @@
 	},
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"sn" = (
+/obj/structure/bed/halflife/mattress/yellowed,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/halflife/indoors/prison/maintenance)
 "so" = (
 /obj/structure/sign/poster/halflife/combine{
 	pixel_y = 32
@@ -3790,6 +4211,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
+"ss" = (
+/obj/structure/halflife/road_barrier/concrete,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "st" = (
 /obj/structure/flora/rock/style_random,
 /turf/open/floor/plating/ground/rockunder,
@@ -3827,6 +4252,17 @@
 /obj/structure/table/halflife/wood/bar,
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/outlands/shop)
+"sA" = (
+/obj/structure/railing/halflife/full{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison)
+"sC" = (
+/obj/item/chair/halflife/metal/office/red/broken,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "sD" = (
 /obj/structure/halflife/leaves,
 /turf/open/floor/plating/ground/dirt,
@@ -3879,6 +4315,10 @@
 "sL" = (
 /turf/open/floor/plating/indoor/carpet,
 /area/halflife/indoors/prison/security/warden)
+"sM" = (
+/obj/machinery/computer/security,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "sN" = (
 /obj/machinery/combine_health_station/round_start{
 	pixel_y = 30
@@ -4021,12 +4461,20 @@
 	dir = 1
 	},
 /area/halflife/outdoors/forest)
+"tt" = (
+/obj/item/radio/intercom/prison/directional/west,
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
 "tu" = (
 /obj/item/card/id/advanced/halflife/orange{
 	registered_name = "Artur Broz"
 	},
 /turf/open/floor/plating/ground/rockunder,
 /area/halflife/indoors/sewer/outlandscave/crabwalker)
+"tv" = (
+/obj/structure/rack,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "tx" = (
 /obj/machinery/camera{
 	c_tag = "Hospital Breakroom";
@@ -4034,6 +4482,13 @@
 	},
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/infirmary)
+"tz" = (
+/obj/machinery/conveyor/auto,
+/obj/machinery/turnstile/brig/halflife/forcefield/civilprotection/nodirectional{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "tA" = (
 /obj/structure/halflife/pipes/horizontal/end,
 /turf/open/floor/plating/indoor/metal/plate,
@@ -4053,6 +4508,11 @@
 "tE" = (
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
+"tF" = (
+/obj/structure/table/halflife/metal/alt,
+/obj/item/storage/dice,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/halflife/indoors/prison/maintenance)
 "tG" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/structure/table/halflife/metal/alt,
@@ -4167,6 +4627,10 @@
 /obj/structure/halflife/tank/dirty_water,
 /turf/open/floor/plating/indoor/concrete/sewer,
 /area/halflife/indoors/sewer)
+"uh" = (
+/obj/item/stack/sheet/mineral/scrap_wood,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/halflife/indoors/prison)
 "ui" = (
 /obj/structure/table/halflife/metal/constructed/cobbled,
 /obj/effect/spawner/random/halflife/loot/alcohol,
@@ -4183,6 +4647,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/factory)
+"um" = (
+/obj/structure/barricade/wooden/solid,
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
 "un" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/indoor/metal/plate,
@@ -4205,11 +4673,9 @@
 /turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison/factory)
 "ur" = (
-/obj/structure/chair/halflife/metal/folding{
-	dir = 1
-	},
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/closet/cabinet,
+/turf/open/floor/plating/indoor/grooved2,
+/area/halflife/indoors/prison)
 "us" = (
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/infirmary)
@@ -4262,6 +4728,11 @@
 /obj/machinery/telecomms/bus/preset_one/birdstation,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/sewer/cave)
+"uI" = (
+/obj/item/stack/sheet/iron/five,
+/obj/item/stack/sheet/scrap_metal,
+/turf/open/floor/plating,
+/area/halflife/indoors/prison)
 "uJ" = (
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/engineering)
@@ -4321,6 +4792,12 @@
 "uV" = (
 /turf/open/floor/plating/indoor/cafeteria,
 /area/halflife/indoors/prison/cafeteria)
+"uX" = (
+/obj/structure/table/halflife/no_smooth/metal,
+/obj/item/reagent_containers/cup/bowl,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "uZ" = (
 /obj/machinery/turnstile/brig/halflife/forcefield/nodirectional,
 /turf/open/floor/plating/indoor/tile,
@@ -4379,6 +4856,11 @@
 /obj/effect/spawner/random/halflife/loot,
 /turf/open/floor/plating/indoor/metal/grate,
 /area/halflife/indoors/sewer)
+"vq" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/porta_turret/combine/off,
+/turf/open/floor/plating/reinforced,
+/area/halflife/indoors/prison)
 "vr" = (
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/sewer)
@@ -4454,6 +4936,12 @@
 	},
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/laborunion)
+"vE" = (
+/obj/structure/window/fulltile/halflife/nosmooth/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tile/navy,
+/area/halflife/indoors/prison)
 "vF" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/indoor/sterilesquares,
@@ -4571,6 +5059,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/outlands/shop)
+"vZ" = (
+/obj/structure/chair/halflife/metal/blue{
+	dir = 8
+	},
+/obj/item/restraints/handcuffs,
+/obj/machinery/combine_walllight/directional/west,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "wa" = (
 /turf/closed/wall/halflife/wood,
 /area/halflife/indoors/sewer/cave)
@@ -4650,6 +5146,11 @@
 	dir = 1
 	},
 /area/halflife/indoors/sewer)
+"wp" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/sign/warning/biohazard/directional/east,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "wr" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/indoor/grooved2,
@@ -4658,6 +5159,12 @@
 /obj/effect/landmark/destabilizer,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cells)
+"wt" = (
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/glasses/sunglasses,
+/obj/structure/table_frame/halflife,
+/turf/open/floor/plating/indoor/metal/grate/border,
+/area/halflife/indoors/prison/maintenance)
 "wu" = (
 /obj/structure/table/halflife/metal,
 /obj/structure/halflife/trash/glass/cans,
@@ -4674,15 +5181,18 @@
 	},
 /turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison/factory)
+"wy" = (
+/obj/structure/broken_flooring/corner/always_floorplane/directional/west,
+/turf/open/floor/plating/ground/dirt,
+/area/halflife/indoors/prison)
 "wz" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plating/ground/rockunder,
 /area/halflife/indoors/sewer/outlandscave/crabwalker)
 "wA" = (
-/obj/structure/closet/halflife,
-/obj/effect/spawner/random/halflife/loot/consumables,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/broken_flooring/pile,
+/turf/open/floor/plating/ground/dirt,
+/area/halflife/indoors/prison)
 "wB" = (
 /obj/machinery/turnstile/brig/halflife/forcefield/science{
 	dir = 1
@@ -4735,6 +5245,9 @@
 /obj/structure/bed/halflife/mattress/yellowed,
 /turf/open/floor/plating/indoor/woodc,
 /area/halflife/outdoors/forest/water)
+"wM" = (
+/turf/open/floor/plating/ground/dirt,
+/area/halflife/indoors/prison)
 "wN" = (
 /obj/structure/chair/halflife/metal/blue{
 	dir = 1
@@ -4758,6 +5271,19 @@
 	},
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/prison/mining)
+"wS" = (
+/obj/structure/fake_stairs/directional/east,
+/obj/structure/curtain/cloth/fancy,
+/obj/structure/fake_stairs/stone{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
+"wT" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "wU" = (
 /obj/machinery/camera{
 	c_tag = "Townhall Broadcast Room";
@@ -5063,6 +5589,10 @@
 /obj/machinery/press,
 /turf/open/floor/plating/indoor/metal/grate/border/warning,
 /area/halflife/indoors/prison/factory)
+"yn" = (
+/obj/structure/halflife/trash/papers/two,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/halflife/indoors/prison/maintenance)
 "yo" = (
 /turf/closed/wall/halflife/sewer,
 /area/halflife/indoors/sewer)
@@ -5133,6 +5663,13 @@
 	},
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands/shop)
+"yA" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 8
+	},
+/obj/machinery/combine_walllight/directional/west,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "yB" = (
 /obj/structure/halflife/sign/combine/prison,
 /turf/open/floor/plating/ground/dirt,
@@ -5344,6 +5881,11 @@
 /obj/structure/halflife/sign/workers,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison)
+"zB" = (
+/obj/structure/halflife/trash/books,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "zC" = (
 /obj/structure/fireplace,
 /turf/open/floor/plating/indoor/concrete/small,
@@ -5402,11 +5944,23 @@
 /obj/structure/halflife/tank,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/maintenance)
+"zQ" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/camera/directional/north{
+	c_tag = "High-Sec Botany"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/halflife/indoors/prison)
 "zR" = (
 /obj/structure/table/halflife/wood/constructed/cobbled,
 /obj/structure/rustic_extractor,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"zS" = (
+/obj/machinery/conveyor/auto,
+/obj/machinery/combine_walllight/directional/east,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "zT" = (
 /obj/machinery/turnstile/brig/halflife/forcefield/loyalists{
 	dir = 4;
@@ -5429,6 +5983,10 @@
 	},
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/halflife/indoors/prison/factory)
+"zY" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/tile,
+/area/halflife/indoors/prison)
 "zZ" = (
 /obj/machinery/vending/breenwater,
 /turf/open/floor/plating/indoor/woodc/mosaic,
@@ -5464,6 +6022,14 @@
 	},
 /turf/open/misc/beach/sand,
 /area/halflife/outdoors/forest)
+"Ag" = (
+/obj/structure/bed/halflife/bedframe/cot{
+	desc = "A cot. Still usable without a mattress, incase you didn't feel like resting on a dead man's one."
+	},
+/obj/structure/bed/halflife/mattress/stained,
+/obj/item/toy/plush/snakeplushie,
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "Ah" = (
 /obj/machinery/camera{
 	c_tag = "Town Hall Medbay";
@@ -5471,6 +6037,10 @@
 	},
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/security)
+"Ai" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plating/indoor/concrete/bricks,
+/area/halflife/indoors/prison)
 "Aj" = (
 /obj/machinery/light/small/cyan/directional/west,
 /turf/open/floor/plating/indoor/sterilesquares,
@@ -5496,6 +6066,16 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/security/warden)
+"Ap" = (
+/obj/structure/railing/halflife/full{
+	dir = 1
+	},
+/obj/structure/halflife/breencast,
+/obj/machinery/camera/directional/north{
+	c_tag = "High-Sec Visitation Upper"
+	},
+/turf/open/floor/plating/indoor/carpet/shaggy/violet,
+/area/halflife/indoors/prison)
 "Aq" = (
 /obj/structure/closet/crate/halflife/wooden,
 /obj/item/light/bulb,
@@ -5555,6 +6135,12 @@
 /obj/structure/halflife/pot/plant,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/engineering)
+"AG" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "High-Sec Laundry Bay"
+	},
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "AH" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/indoor/woodc,
@@ -5615,6 +6201,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
+"AU" = (
+/obj/structure/broken_flooring/pile/always_floorplane/directional/west,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "AV" = (
 /obj/structure/closet/halflife,
 /turf/open/floor/plating/indoor/concrete,
@@ -5632,9 +6222,11 @@
 /turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security/solitary)
 "Ba" = (
-/obj/structure/window/fulltile/halflife/nosmooth/reinforced,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "workbay"
+	},
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "Bd" = (
 /obj/effect/mob_spawn/corpse/human/refugee,
 /turf/open/floor/plating/indoor/woodc/wide,
@@ -5658,6 +6250,16 @@
 /obj/structure/flora/xen/leafy,
 /turf/open/floor/plating/indoor/metal/grate,
 /area/halflife/outdoors/forest/water)
+"Bi" = (
+/obj/structure/halflife/trash/garbage/dumpster,
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/halflife/indoors/prison/security)
+"Bj" = (
+/obj/structure/rack,
+/obj/item/radio/entertainment/microphone/physical,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating/indoor/woodc,
+/area/halflife/indoors/prison)
 "Bk" = (
 /obj/structure/closet/crate/halflife,
 /obj/item/stack/sticky_tape,
@@ -5673,6 +6275,10 @@
 	},
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"Bm" = (
+/obj/machinery/light/small/blacklight/directional/south,
+/turf/open/floor/plating/indoor/concrete,
+/area/halflife/indoors/prison)
 "Bo" = (
 /obj/machinery/camera{
 	c_tag = "Southwest Exit Hallway North"
@@ -5688,6 +6294,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
+"Br" = (
+/obj/structure/halflife/pot/plant,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "Bs" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plating/indoor/sterilesquares,
@@ -5926,6 +6536,12 @@
 /obj/structure/halflife/trash/garbage,
 /turf/open/floor/plating/ground/sidewalk/inner/slums,
 /area/halflife/outdoors/forest)
+"Cy" = (
+/obj/machinery/turnstile/brig/halflife/forcefield/civilprotection/nodirectional{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/halflife/indoors/prison/security)
 "Cz" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating/indoor/metal/industrial,
@@ -5950,6 +6566,28 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/infirmary)
+"CE" = (
+/obj/structure/steam_vent{
+	desc = "A large and oversized vent, looks suspicious. The bars on it have been torn and shredded, with the interior sealed, leading to a build-up of stale air.";
+	name = "hatch vent"
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
+"CF" = (
+/obj/item/kitchen/spoon/soup_ladle,
+/obj/item/kitchen/spoon/soup_ladle,
+/obj/item/kitchen/spoon/soup_ladle,
+/obj/item/kitchen/spoon/soup_ladle,
+/obj/item/kitchen/spoon/soup_ladle,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/structure/table/halflife/metal/grate,
+/turf/open/floor/plating/indoor/tile/navy,
+/area/halflife/indoors/prison)
 "CG" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small/directional/south,
@@ -5965,6 +6603,11 @@
 	},
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/infirmary)
+"CJ" = (
+/obj/structure/window/fulltile/halflife/nosmooth/reinforced,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/halflife/indoors/prison)
 "CK" = (
 /obj/structure/rack,
 /obj/item/hl2key/hospital,
@@ -6091,10 +6734,8 @@
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/outdoors/forest)
 "Dk" = (
-/obj/structure/closet/halflife/wall/firstaid,
-/obj/effect/spawner/random/halflife/loot/heal,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/turf/open/floor/plating/indoor/grooved2,
+/area/halflife/indoors/prison)
 "Dl" = (
 /obj/machinery/door/unpowered/halflife/wood{
 	keylock = 1;
@@ -6145,9 +6786,16 @@
 /obj/structure/alien/weeds/node,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands)
+"Dw" = (
+/obj/structure/broken_flooring/pile/directional/north,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/halflife/indoors/prison)
 "Dx" = (
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest/prison_yard)
+"Dy" = (
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/halflife/indoors/prison/security)
 "Dz" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/indoor/lino,
@@ -6175,6 +6823,13 @@
 /obj/structure/table/halflife/wood/constructed/cobbled,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"DG" = (
+/obj/machinery/conveyor/auto,
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Motorway A"
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "DH" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small/directional/west,
@@ -6194,6 +6849,16 @@
 /obj/machinery/vending/breenwater,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/infirmary)
+"DM" = (
+/obj/structure/table/halflife/wood,
+/obj/structure/halflife/trash/cardboard{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/radio/intercom,
+/turf/open/floor/plating/indoor/tile,
+/area/halflife/indoors/prison)
 "DN" = (
 /obj/item/wallframe/newscaster,
 /obj/structure/closet/crate/halflife,
@@ -6231,6 +6896,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/mining)
+"DS" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/ground/sidewalk/inner/slums,
+/area/halflife/indoors/prison)
 "DT" = (
 /obj/structure/closet/halflife,
 /turf/open/floor/plating/indoor/woodc,
@@ -6247,6 +6916,10 @@
 "DX" = (
 /obj/structure/halflife/pot/plant,
 /turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
+"DZ" = (
+/obj/structure/bed/halflife/mattress/yellowed,
+/turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/prison)
 "Eb" = (
 /obj/structure/lattice/catwalk/hl13,
@@ -6431,6 +7104,10 @@
 	},
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/commissary)
+"ER" = (
+/obj/machinery/atm,
+/turf/open/floor/plating/indoor/tile/navy,
+/area/halflife/indoors/prison)
 "ES" = (
 /obj/machinery/shower/halflife{
 	dir = 1
@@ -6501,9 +7178,20 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison)
+"Ff" = (
+/obj/item/stack/sheet/mineral/scrap_wood,
+/turf/open/floor/plating/indoor/metal/grate/border,
+/area/halflife/indoors/prison)
 "Fg" = (
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison)
+"Fh" = (
+/obj/machinery/door/window/brigdoor/security/holding/left/directional/south{
+	dir = 1
+	},
+/obj/structure/table/halflife/metal/heavy,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "Fi" = (
 /obj/structure/table/halflife/no_smooth/large/crafting/armorbench{
 	pixel_y = -6
@@ -6536,12 +7224,8 @@
 /turf/open/floor/plating/indoor/lino,
 /area/halflife/indoors/outlands)
 "Fo" = (
-/obj/structure/closet/halflife,
-/obj/effect/spawner/random/halflife/loot,
-/obj/effect/spawner/random/halflife/loot,
-/obj/effect/spawner/random/halflife/loot/uncommon,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison)
 "Fp" = (
 /obj/machinery/bio_processor,
 /turf/open/floor/plating/indoor/metal/industrial,
@@ -6626,6 +7310,11 @@
 /obj/structure/halflife/trash/garbage/dumpster/crate,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cells)
+"FE" = (
+/obj/structure/railing,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "FF" = (
 /obj/item/chair/halflife/metal/blue,
 /turf/open/floor/plating/indoor/tile,
@@ -6643,6 +7332,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/infirmary)
+"FJ" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "FK" = (
 /obj/structure/halflife/tv/tube/small{
 	pixel_y = 12
@@ -6726,6 +7419,9 @@
 /obj/structure/halflife/road_barrier,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"Gb" = (
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "Gc" = (
 /obj/structure/weightmachine,
 /turf/open/floor/plating/indoor/concrete/small,
@@ -6763,6 +7459,10 @@
 	},
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/factory)
+"Gk" = (
+/obj/machinery/combine_walllight/directional/west,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "Gl" = (
 /turf/closed/mineral/random,
 /area/halflife/outdoors/forest/water)
@@ -6806,10 +7506,23 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cargo)
+"Gv" = (
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "Gw" = (
 /obj/structure/closet/halflife,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/sewer)
+"Gx" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "High-Sec Hall"
+	},
+/turf/open/floor/plating/indoor/concrete,
+/area/halflife/indoors/prison)
 "Gy" = (
 /obj/structure/halflife/leaves,
 /turf/open/floor/plating/ground/grass,
@@ -6829,6 +7542,11 @@
 /obj/item/hl2key/maint,
 /obj/item/hl2key/maint,
 /obj/item/hl2key/maint,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
+"GC" = (
+/obj/structure/closet/secure_closet/halflife,
+/obj/machinery/combine_walllight/directional/east,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
 "GD" = (
@@ -6920,6 +7638,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/factory)
+"GX" = (
+/obj/structure/closet/secure_closet/halflife,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "GY" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -6949,11 +7671,17 @@
 /obj/structure/halflife/typewriter,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/bunker)
+"Hf" = (
+/obj/structure/stairs/halflife/concrete{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/tile,
+/area/halflife/indoors/prison)
 "Hg" = (
 /turf/open/floor/plating/indoor/metal/pipe/corner{
 	dir = 8
 	},
-/area/halflife/indoors/prison/maintenance)
+/area/halflife/indoors/prison/security)
 "Hh" = (
 /obj/item/reagent_containers/syringe,
 /obj/machinery/chem_mass_spec,
@@ -7020,6 +7748,10 @@
 "Hu" = (
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/halflife/indoors/outlands)
+"Hv" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/checkered,
+/area/halflife/indoors/prison)
 "Hw" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/halflife/metal/small,
@@ -7053,6 +7785,10 @@
 /obj/item/soap,
 /turf/open/floor/plating/indoor/grooved2,
 /area/halflife/indoors/prison/cells)
+"HA" = (
+/obj/machinery/shower/directional/west,
+/turf/open/floor/plating/ground/sidewalk/inner/slums,
+/area/halflife/indoors/prison)
 "HC" = (
 /mob/living/carbon/human/species/stalker,
 /turf/open/floor/plating/indoor/metal/smooth,
@@ -7117,6 +7853,13 @@
 /obj/structure/window/fulltile/halflife/nosmooth/reinforced,
 /turf/open/floor/plating/indoor/woodc,
 /area/halflife/indoors/prison/commissary)
+"HN" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 4
+	},
+/obj/machinery/combine_walllight/directional/east,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "HO" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/indoor/trainfloor,
@@ -7212,6 +7955,10 @@
 /obj/structure/halflife/barrel/triple/grey,
 /turf/open/floor/plating/indoor/metal/grate,
 /area/halflife/indoors/sewer)
+"Ij" = (
+/obj/item/trash/halflife/nutrient_bar_waste/pork,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/halflife/indoors/prison)
 "Ik" = (
 /obj/machinery/door/unpowered/halflife/seethrough/metal{
 	dir = 8
@@ -7288,7 +8035,7 @@
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/gym)
 "IC" = (
-/obj/structure/window/fulltile/halflife/nosmooth/brick,
+/obj/structure/window/fulltile/halflife/nosmooth/reinforced,
 /turf/open/floor/plating/indoor/tile,
 /area/halflife/indoors/prison)
 "ID" = (
@@ -7298,6 +8045,15 @@
 	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/entrance)
+"IE" = (
+/obj/structure/railing/halflife/full{
+	dir = 5
+	},
+/obj/structure/railing/halflife/full{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison)
 "IF" = (
 /obj/structure/halflife/trash/papers/one{
 	pixel_x = -2;
@@ -7320,6 +8076,13 @@
 /obj/structure/bed/medical,
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/security)
+"IJ" = (
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "visitation_gate"
+	},
+/turf/open/floor/plating/indoor/metal/grate/border/warning,
+/area/halflife/indoors/prison)
 "IK" = (
 /obj/structure/halflife/trash/papers/one{
 	dir = 4
@@ -7380,6 +8143,10 @@
 "IV" = (
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/factory)
+"IW" = (
+/obj/structure/mop_bucket/janitorialcart,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "IX" = (
 /obj/structure/table/halflife/wood,
 /obj/effect/spawner/random/halflife/loot/ammo,
@@ -7424,10 +8191,22 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/gym)
+"Jh" = (
+/obj/machinery/turnstile/brig/halflife/forcefield/curfew{
+	name = "Quarantine Cell";
+	desc = "The sensors on this forcefield have been shorted from damage, reverting its behavior to the backup of curfew times instead of its original purpose."
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/halflife/indoors/prison)
 "Jj" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/indoor/woodc,
 /area/halflife/indoors/laborunion)
+"Jk" = (
+/obj/item/shovel,
+/turf/open/floor/plating/indoor/woodc/mosaic,
+/area/halflife/indoors/prison)
 "Jl" = (
 /obj/effect/spawner/random/halflife/random_zombie,
 /turf/open/floor/plating/ground/grass,
@@ -7464,6 +8243,10 @@
 	},
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/outdoors/forest/water)
+"Jt" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "Ju" = (
 /obj/structure/table/halflife/no_smooth/metal,
 /obj/machinery/ration_vendor{
@@ -7530,6 +8313,12 @@
 	},
 /turf/open/floor/plating/indoor/tiled9,
 /area/halflife/indoors/prison/infirmary)
+"JM" = (
+/obj/structure/table/halflife/wood,
+/obj/structure/halflife/trash/papers/three,
+/obj/item/radio/intercom,
+/turf/open/floor/plating/indoor/tile,
+/area/halflife/indoors/prison)
 "JN" = (
 /turf/open/floor/plating/indoor/metal/walkway/corner{
 	dir = 8
@@ -7539,6 +8328,10 @@
 /obj/structure/halflife/storage/large/shelf/wood,
 /turf/open/floor/plating/indoor/tile,
 /area/halflife/indoors/prison/cells)
+"JP" = (
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "JQ" = (
 /obj/structure/halflife/trash/garbage,
 /turf/open/floor/plating/indoor/metal/plate,
@@ -7613,6 +8406,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest)
+"Ki" = (
+/obj/structure/halflife/breencast,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "Kk" = (
 /obj/machinery/camera{
 	c_tag = "Cell R5";
@@ -7631,6 +8428,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/indoor/trainfloor,
 /area/halflife/indoors/prison/intake)
+"Ko" = (
+/obj/structure/halflife/trash/books/pile_alt,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison/maintenance)
 "Kp" = (
 /obj/structure/mop_bucket/janitorialcart,
 /obj/item/mop,
@@ -7729,6 +8530,15 @@
 	dir = 1
 	},
 /area/halflife/outdoors/forest/water)
+"KL" = (
+/obj/structure/curtain,
+/turf/open/floor/plating/ground/sidewalk/inner/slums,
+/area/halflife/indoors/prison)
+"KM" = (
+/obj/item/stack/sheet/scrap_parts,
+/obj/item/ammo_box/magazine/pulsesmg,
+/turf/open/floor/plating/reinforced,
+/area/halflife/indoors/prison)
 "KN" = (
 /obj/machinery/door/unpowered/halflife/seethrough/grate,
 /turf/open/floor/plating/indoor/metal/plate,
@@ -7748,6 +8558,10 @@
 	},
 /turf/open/floor/plating/indoor/tile/kitchen,
 /area/halflife/indoors/prison/cafeteria)
+"KR" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "KU" = (
 /obj/structure/railing/halflife/sewer{
 	dir = 1
@@ -7773,9 +8587,7 @@
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cells)
 "La" = (
-/obj/structure/window/fulltile/halflife/nosmooth/reinforced,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/indoor/tile,
+/turf/open/floor/plating/indoor/tile/kitchen,
 /area/halflife/indoors/prison)
 "Lb" = (
 /obj/structure/halflife/trash/glass/basic,
@@ -7910,6 +8722,12 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cells)
+"LC" = (
+/obj/structure/table/halflife/no_smooth/large/metal/desk,
+/obj/item/paper_bin,
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "LD" = (
 /obj/structure/table/halflife/metal/grate,
 /obj/item/hl2key/factory,
@@ -7919,6 +8737,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"LE" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "LF" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/utility/radiation/cleanup,
@@ -7944,15 +8766,21 @@
 /obj/machinery/vending/breenwater,
 /turf/open/floor/plating/indoor/woodc,
 /area/halflife/indoors/prison/entrance)
+"LJ" = (
+/obj/machinery/vending/breenwater,
+/turf/open/floor/plating/indoor/tile/navy,
+/area/halflife/indoors/prison)
 "LK" = (
 /obj/effect/turf_decal/halflife/covering/tiles/white,
 /turf/closed/wall/halflife/brick/grey,
 /area/halflife/indoors/prison/infirmary)
 "LL" = (
-/obj/structure/chair/halflife/metal/stool,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "LM" = (
 /mob/living/basic/halflife/grub,
 /turf/open/floor/plating/ground/rockunder,
@@ -8057,6 +8885,10 @@
 	dir = 1
 	},
 /area/halflife/indoors/sewer)
+"Mg" = (
+/obj/structure/broken_flooring/plating/always_floorplane/directional/east,
+/turf/open/floor/plating/ground/dirt,
+/area/halflife/indoors/prison)
 "Mi" = (
 /obj/structure/railing/halflife/solo{
 	dir = 1
@@ -8110,6 +8942,13 @@
 /obj/machinery/vending/civpro,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"Ms" = (
+/obj/structure/railing/halflife/full{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison)
 "Mt" = (
 /obj/structure/chair/halflife/metal/blue{
 	dir = 1
@@ -8125,6 +8964,12 @@
 	},
 /turf/open/floor/plating/indoor/cafeteria,
 /area/halflife/indoors/prison/cafeteria)
+"Mx" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "My" = (
 /turf/closed/mineral/random,
 /area/halflife/indoors/sewer/outlandscave/crabwalker)
@@ -8159,6 +9004,17 @@
 /obj/structure/table/halflife/no_smooth/large/wood/square,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/entrance)
+"MI" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
+"MJ" = (
+/obj/structure/window/fulltile/halflife/nosmooth/reinforced,
+/turf/open/floor/plating,
+/area/halflife/indoors/prison)
 "MK" = (
 /obj/structure/railing/halflife/wood/single,
 /turf/open/misc/beach/sand,
@@ -8333,6 +9189,29 @@
 /obj/structure/railing/halflife/sewer,
 /turf/open/floor/plating/indoor/concrete/sewer,
 /area/halflife/indoors/sewer)
+"Nr" = (
+/obj/structure/closet/crate/halflife/wooden,
+/obj/item/seeds/carrot,
+/obj/item/seeds/carrot,
+/obj/item/seeds/chanter,
+/obj/item/seeds/apple,
+/obj/item/seeds/apple,
+/obj/item/seeds/banana,
+/obj/item/seeds/banana,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/onion,
+/obj/item/seeds/onion,
+/obj/item/seeds/orange,
+/obj/item/seeds/orange,
+/obj/item/seeds/tomato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "Ns" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/plating/ground/dirt,
@@ -8369,6 +9248,13 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/engineering)
+"Ny" = (
+/obj/structure/signpost{
+	desc = "Please keep all prisoners within reach when using the motorway, and exit on in orderly fashion. If transporting multiple prisoners, wait a small duration of time before following behing a convoy to prevent jams when the motorway is being exited.";
+	name = "High-Security Transport Disclaimer"
+	},
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "Nz" = (
 /obj/machinery/door/unpowered/halflife/seethrough/bar{
 	keylock = 1;
@@ -8384,6 +9270,13 @@
 	},
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands)
+"NB" = (
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "visitation_gate"
+	},
+/turf/open/floor/plating/indoor/metal/grate,
+/area/halflife/indoors/prison)
 "NC" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating/ground/rockunder,
@@ -8403,6 +9296,28 @@
 /obj/effect/spawner/random/halflife/plant_spawner,
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest/prison_yard)
+"NI" = (
+/obj/structure/closet/crate/halflife/wooden,
+/obj/machinery/camera{
+	c_tag = "High-Sec Gate Backroom";
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
+"NJ" = (
+/obj/structure/rack,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/obj/item/food/nutripaste/small,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "NK" = (
 /obj/structure/table/halflife/metal/constructed/cobbled,
 /obj/effect/spawner/random/halflife/loot/consumables,
@@ -8535,11 +9450,11 @@
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/security/warden)
 "On" = (
-/obj/structure/chair/halflife/metal/folding{
+/obj/machinery/turnstile/brig/halflife/forcefield/curfew{
 	dir = 4
 	},
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/turf/open/floor/plating/indoor/checkered,
+/area/halflife/indoors/prison)
 "Oo" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/plating/ground/grass,
@@ -8582,6 +9497,10 @@
 /obj/structure/halflife/tank/pipe,
 /turf/open/floor/plating/indoor/metal/pipe,
 /area/halflife/indoors/sewer)
+"Ow" = (
+/obj/item/radio/intercom/prison/directional/east,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "Ox" = (
 /obj/structure/railing/halflife/solo{
 	dir = 4
@@ -8620,6 +9539,10 @@
 /obj/structure/bed/halflife/mattress/stained,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"OH" = (
+/obj/structure/halflife/trash/cardboard,
+/turf/open/floor/plating/indoor/concrete,
+/area/halflife/indoors/prison)
 "OI" = (
 /obj/structure/railing/halflife/solo,
 /obj/effect/spawner/random/halflife/plant_spawner,
@@ -8679,6 +9602,13 @@
 /obj/structure/halflife/trash/garbage,
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest)
+"OT" = (
+/obj/item/emptysandbag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "visitation_gate"
+	},
+/turf/open/floor/plating/indoor/metal/grate/border/warning,
+/area/halflife/indoors/prison)
 "OU" = (
 /turf/open/halflife/water/salt/shallow,
 /area/halflife/outdoors/forest/water)
@@ -8729,10 +9659,24 @@
 	},
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/infirmary)
+"Pe" = (
+/obj/structure/railing/halflife/full{
+	dir = 9
+	},
+/obj/structure/railing/halflife/full{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "Pf" = (
 /obj/machinery/atm,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/commissary)
+"Pg" = (
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/clothing/suit/bluejacket,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "Ph" = (
 /obj/structure/halflife/tv/tube{
 	dir = 8
@@ -8868,6 +9812,11 @@
 "PK" = (
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/outdoors/forest/water)
+"PL" = (
+/obj/structure/table/halflife/no_smooth/metal,
+/obj/item/reagent_containers/cup/bowl,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "PM" = (
 /obj/structure/halflife/storage/store,
 /turf/open/floor/plating/indoor/woodc/mosaic,
@@ -8884,6 +9833,11 @@
 "PP" = (
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/dispatch)
+"PQ" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/machinery/coffeemaker/impressa,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "PR" = (
 /obj/structure/chair/halflife/metal/folding{
 	dir = 4
@@ -9087,14 +10041,12 @@
 /obj/structure/halflife/rug,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/entrance)
-"QN" = (
-/obj/machinery/light/directional/south,
-/obj/structure/halflife/trash/cardboard{
-	dir = 8;
-	pixel_x = 2;
-	pixel_y = 11
-	},
+"QM" = (
+/obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
+"QN" = (
+/turf/open/floor/plating/indoor/tile/navy,
 /area/halflife/indoors/prison)
 "QO" = (
 /obj/machinery/clothes_vendor{
@@ -9129,6 +10081,11 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison)
+"QV" = (
+/obj/structure/bed/halflife/bedframe/wire,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/grooved2,
+/area/halflife/indoors/prison)
 "QW" = (
 /mob/living/basic/halflife/zombie/fungal,
 /turf/open/floor/plating/indoor/woodc/wide,
@@ -9143,6 +10100,14 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest/prison_yard)
+"Rc" = (
+/obj/structure/reagent_dispensers/servingdish,
+/obj/structure/table/halflife/metal,
+/obj/machinery/camera/directional/north{
+	c_tag = "High-Sec Cafeteria"
+	},
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "Rd" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/table/halflife/no_smooth/metal,
@@ -9224,6 +10189,9 @@
 	},
 /turf/open/floor/plating/indoor/concrete/sewer,
 /area/halflife/indoors/sewer)
+"Rv" = (
+/turf/closed/wall/halflife/metal,
+/area/halflife/indoors/prison/maintenance)
 "Rw" = (
 /obj/structure/table/halflife/wood/constructed,
 /obj/item/reagent_containers/pill/patch/medkit/vial,
@@ -9246,6 +10214,15 @@
 "RB" = (
 /turf/open/halflife/water/salt/deep,
 /area/halflife/outdoors/forest/water)
+"RD" = (
+/obj/structure/rack,
+/obj/item/storage/bag/money,
+/obj/item/cultivator/rake{
+	desc = "A very ineffective way of gathering chips off of poker tables. The house always wins."
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison/maintenance)
 "RE" = (
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison)
@@ -9307,6 +10284,18 @@
 	},
 /turf/open/floor/plating/indoor/trainfloor,
 /area/halflife/indoors/prison/intake)
+"RT" = (
+/obj/machinery/door/unpowered/halflife/seethrough/bar{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/grooved2,
+/area/halflife/indoors/prison)
+"RU" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "RV" = (
 /obj/machinery/camera{
 	c_tag = "Labor Union";
@@ -9347,6 +10336,11 @@
 	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison)
+"Se" = (
+/obj/machinery/conveyor/auto,
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "Sf" = (
 /obj/effect/spawner/random/halflife/loot/heal,
 /turf/open/floor/plating/ground/rockunder,
@@ -9408,6 +10402,13 @@
 	},
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands)
+"Sq" = (
+/obj/structure/halflife/road_barrier/concrete/alt{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
 "Sr" = (
 /obj/machinery/camera{
 	c_tag = "Divisional Lead Office";
@@ -9418,6 +10419,11 @@
 "Ss" = (
 /turf/open/floor/plating/indoor/trainfloor,
 /area/halflife/indoors/prison/intake)
+"St" = (
+/obj/structure/table/halflife/no_smooth/dice,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plating/indoor/carpet,
+/area/halflife/indoors/prison/maintenance)
 "Su" = (
 /obj/docking_port/stationary{
 	name = "arrivals";
@@ -9441,6 +10447,11 @@
 "Sw" = (
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cargo)
+"Sx" = (
+/obj/structure/table/halflife/metal/grate,
+/obj/structure/halflife/trash/garbage,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/prison)
 "Sy" = (
 /obj/machinery/combine_walllight/directional/north,
 /turf/open/floor/plating/indoor/metal/smooth,
@@ -9496,6 +10507,13 @@
 /obj/effect/spawner/random/halflife/loot,
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/bunker)
+"SL" = (
+/obj/structure/railing/halflife/full{
+	dir = 1
+	},
+/obj/item/radio/intercom/prison/directional/south,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison)
 "SM" = (
 /obj/structure/chair/halflife/metal/blue{
 	dir = 1
@@ -9554,6 +10572,10 @@
 	},
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/security/warden)
+"SW" = (
+/obj/machinery/clothes_vendor,
+/turf/closed/wall/halflife/concrete/alt,
+/area/halflife/indoors/prison)
 "SX" = (
 /obj/structure/table/halflife/metal/grate,
 /obj/machinery/recharger{
@@ -9574,6 +10596,10 @@
 /mob/living/basic/trooper/rebel/mp7/refugee,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands/shop)
+"Ta" = (
+/obj/structure/closet/crate/halflife/wooden,
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "Tb" = (
 /obj/structure/halflife/trash/bricks,
 /turf/open/floor/plating/indoor/concrete/sewer,
@@ -9695,6 +10721,11 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
+"TE" = (
+/obj/structure/table/halflife/no_smooth/large/wood,
+/obj/effect/spawner/random/halflife/loot/alcohol,
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "TF" = (
 /obj/machinery/door/unpowered/halflife/metal/red{
 	dir = 4
@@ -9746,6 +10777,12 @@
 	},
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands)
+"TS" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Service Line"
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison)
 "TT" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/plating/indoor/concrete/small,
@@ -9776,6 +10813,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/indoor/woodc,
 /area/halflife/indoors/laborunion)
+"Ua" = (
+/obj/structure/rack,
+/obj/item/soap/homemade,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "Ub" = (
 /obj/structure/punching_bag,
 /turf/open/floor/plating/indoor/concrete/small,
@@ -9867,6 +10909,13 @@
 /obj/machinery/cryopod,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"Uv" = (
+/turf/open/floor/plating/indoor/woodc/wide,
+/area/halflife/indoors/prison)
+"Uw" = (
+/obj/structure/halflife/fence/wire,
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison/cells)
 "Ux" = (
 /obj/structure/bed/halflife/mattress/old,
 /turf/open/floor/plating/indoor/woodc/wide,
@@ -9905,6 +10954,10 @@
 "UG" = (
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/infirmary)
+"UH" = (
+/obj/structure/barricade/wooden/solid,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "UI" = (
 /obj/structure/table/halflife/no_smooth/large/wood/desk{
 	dir = 1
@@ -9954,6 +11007,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest)
+"UV" = (
+/obj/structure/bed/halflife/bedframe/wire,
+/turf/open/floor/plating/indoor/grooved2,
+/area/halflife/indoors/prison)
 "UX" = (
 /mob/living/silicon/robot/cityscanner/dispatch_shell,
 /turf/open/floor/plating/indoor/metal/smooth,
@@ -9961,6 +11018,11 @@
 "UZ" = (
 /turf/open/floor/plating/indoor/trainfloor,
 /area/halflife/indoors/prison)
+"Va" = (
+/obj/item/rack_parts,
+/obj/effect/spawner/random/halflife/loot/gun_frame,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "Vb" = (
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plating/indoor/concrete,
@@ -9982,6 +11044,9 @@
 /obj/machinery/light/small/cyan/directional/east,
 /turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security/armory)
+"Vg" = (
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison/maintenance)
 "Vh" = (
 /obj/structure/flora/xen/leafy,
 /turf/open/floor/plating/indoor/woodc/wide,
@@ -10030,6 +11095,13 @@
 /obj/structure/halflife/pallet/stack,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/engineering)
+"Vq" = (
+/obj/structure/table_frame/halflife/wood,
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating/indoor/tile/kitchen,
+/area/halflife/indoors/prison)
 "Vr" = (
 /obj/structure/closet/halflife,
 /obj/item/bodypart/arm/left/robot/surplus,
@@ -10052,6 +11124,11 @@
 /obj/structure/closet/halflife,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/cells)
+"Vu" = (
+/obj/structure/broken_flooring/side,
+/obj/effect/decal/cleanable/food/egg_smudge,
+/turf/open/floor/plating/indoor/woodc/mosaic,
+/area/halflife/indoors/prison)
 "Vw" = (
 /obj/structure/table/halflife/wood,
 /obj/structure/halflife/trash/food/dinner,
@@ -10062,10 +11139,19 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/dispatch)
+"Vz" = (
+/obj/item/spess_knife,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "VB" = (
 /mob/living/basic/halflife/antlion_worker,
 /turf/open/floor/plating/ground/rockunder,
 /area/halflife/indoors/sewer/outlandscave)
+"VC" = (
+/obj/item/rack_parts,
+/obj/effect/spawner/random/halflife/loot/trash,
+/turf/open/floor/plating/indoor/carpet/shaggy,
+/area/halflife/indoors/prison)
 "VD" = (
 /obj/machinery/camera{
 	c_tag = "Mine Upper";
@@ -10074,6 +11160,12 @@
 /obj/structure/halflife/trash/garbage/dumpster/crate,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/mining)
+"VE" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Service Booth"
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "VI" = (
 /obj/item/surgicaldrill,
 /obj/item/cautery,
@@ -10087,6 +11179,10 @@
 "VK" = (
 /turf/closed/wall/halflife/concrete/bunker,
 /area/halflife/indoors/prison/engineering)
+"VM" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "VN" = (
 /obj/structure/stairs/halflife/concrete,
 /turf/open/floor/plating/indoor/concrete/sewer,
@@ -10203,6 +11299,14 @@
 	},
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/prison/factory)
+"Wh" = (
+/obj/structure/table/halflife/wood/constructed/cobbled,
+/obj/item/pushbroom,
+/obj/machinery/camera/directional/north{
+	c_tag = "High-Sec Janitorial"
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "Wi" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Rails Exterior";
@@ -10358,10 +11462,23 @@
 "WO" = (
 /turf/closed/wall/halflife/concrete/bunker,
 /area/halflife/indoors/outlands)
+"WP" = (
+/obj/structure/chair/office/halflife/blue,
+/obj/machinery/button/door/directional/east{
+	id = "workbay";
+	name = "work shutdown button";
+	desc = "This button remotely closes and opens the laundry bay, to encourage proper working hours."
+	},
+/turf/open/floor/plating/indoor/metal/combine,
+/area/halflife/indoors/prison/security)
 "WQ" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison/factory)
+"WR" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plating/indoor/tile,
+/area/halflife/indoors/prison)
 "WS" = (
 /obj/machinery/gibber,
 /obj/effect/decal/cleanable/blood/old,
@@ -10504,10 +11621,12 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/sewer/cave)
 "XD" = (
-/turf/open/floor/plating/indoor/metal/pipe/intersection{
-	dir = 4
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/area/halflife/indoors/prison/maintenance)
+/obj/machinery/turnstile/brig/halflife/forcefield/civilprotection/nodirectional,
+/turf/open/floor/plating/indoor/metal/smooth,
+/area/halflife/indoors/prison/security)
 "XE" = (
 /obj/effect/spawner/random/halflife/loot/trash,
 /turf/open/floor/plating/indoor/grooved2,
@@ -10589,6 +11708,12 @@
 /obj/machinery/combine_walllight/directional/east,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
+"Yb" = (
+/obj/structure/chair/sofa/left{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/carpet/shaggy/blue,
+/area/halflife/indoors/prison)
 "Yc" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/indoor/tile,
@@ -10620,6 +11745,11 @@
 /obj/effect/spawner/random/halflife/loot/heal,
 /turf/open/floor/plating/ground/rockunder,
 /area/halflife/indoors/sewer/cave)
+"Yl" = (
+/obj/structure/broken_flooring/pile,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/halflife/indoors/prison)
 "Ym" = (
 /obj/structure/halflife/breencast,
 /turf/closed/wall/halflife/concrete/bunker,
@@ -10655,6 +11785,10 @@
 /obj/item/hl13_small_flag/combine,
 /turf/open/floor/plating/indoor/carpet,
 /area/halflife/indoors/laborunion)
+"Yu" = (
+/obj/structure/halflife/road_barrier/concrete/alt,
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
 "Yv" = (
 /obj/structure/halflife/trash/papers/one{
 	dir = 1
@@ -10685,6 +11819,10 @@
 /obj/structure/halflife/trash/wood,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest/prison_yard)
+"YA" = (
+/obj/item/stack/sheet/mineral/scrap_wood,
+/turf/open/floor/plating/indoor/tile/black,
+/area/halflife/indoors/prison)
 "YB" = (
 /turf/closed/wall/halflife/concrete/alt,
 /area/halflife/indoors/prison/commissary)
@@ -10773,6 +11911,10 @@
 /obj/effect/spawner/random/halflife/loot,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands)
+"YQ" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "YR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/indoor/woodc/wide,
@@ -10809,6 +11951,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/entrance)
+"Za" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison)
 "Zb" = (
 /turf/open/floor/plating/ground/sidewalk/inner/slums,
 /area/halflife/outdoors/forest)
@@ -62118,7 +63264,7 @@ mJ
 mJ
 zW
 zW
-HQ
+Uw
 Fe
 RE
 RE
@@ -62131,7 +63277,7 @@ RE
 RE
 RE
 RE
-kz
+nD
 RE
 IN
 KX
@@ -62335,7 +63481,7 @@ IN
 IN
 IN
 IN
-jL
+Fl
 IN
 IN
 IN
@@ -62526,7 +63672,7 @@ mJ
 mJ
 zW
 zW
-HQ
+Uw
 RE
 RE
 RE
@@ -62539,7 +63685,7 @@ IN
 RE
 RE
 RE
-kz
+nD
 RE
 IN
 RE
@@ -62739,7 +63885,7 @@ HQ
 nD
 nD
 nD
-Fl
+On
 nD
 nD
 nD
@@ -62947,12 +64093,12 @@ IN
 QE
 RL
 IC
-RL
+pL
 SM
 IN
 RE
 nD
-Ct
+tc
 Ct
 Ct
 Lk
@@ -63155,8 +64301,8 @@ nD
 GL
 IN
 RE
-La
-Lk
+nD
+tc
 Lk
 Lk
 Ct
@@ -63355,12 +64501,12 @@ IN
 QE
 bz
 IC
-RL
+pL
 UB
 FF
 Nk
 nD
-Ct
+tc
 Ct
 Ct
 Ct
@@ -63554,17 +64700,17 @@ QJ
 ox
 nD
 nD
-se
+Ak
 IN
 IN
 nD
 nD
 nD
-GL
-IN
-QN
 nD
-Ct
+Hf
+Tg
+nD
+tc
 Ct
 Ct
 Ct
@@ -63760,16 +64906,16 @@ nD
 nD
 RE
 IN
-IN
+WR
 nD
 nD
 nD
-GL
-IN
+nD
+Hf
 RE
 nD
+tc
 CV
-Ct
 Ct
 Ct
 Ct
@@ -63964,15 +65110,15 @@ nD
 nD
 RE
 IN
-FF
-RL
-IC
-lD
-SM
 IN
+nD
+nD
+nD
+nD
+Hf
 RE
 nD
-Ct
+tc
 Ct
 Ct
 Lk
@@ -64168,15 +65314,15 @@ nD
 nD
 RE
 kR
-IN
-nD
-nD
-nD
-GL
+FF
+RL
+IC
+JM
+SM
 IN
 RE
-La
-Lk
+nD
+tc
 Lk
 Lk
 Lk
@@ -64373,14 +65519,14 @@ nD
 gs
 PV
 QE
-RL
-IC
-qa
-SM
+nD
+nD
+nD
+GL
 IN
 RE
 nD
-Ct
+tc
 Lk
 Ct
 Lk
@@ -64574,17 +65720,17 @@ HQ
 HQ
 nD
 nD
+RE
+RE
+RE
+RL
+IC
+DM
+RE
+RE
+RE
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Ct
+tc
 qt
 Ct
 Ct
@@ -64777,18 +65923,18 @@ nD
 nD
 nD
 nD
-Ct
-Ct
-Lk
-Lk
-Ct
-Lk
-Ct
-qt
-Ct
-Lk
-Lk
-Lk
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
 Lk
 Lk
 Ct
@@ -64980,19 +66126,19 @@ qt
 Ct
 Ct
 os
-Ct
-Ct
-Ct
-Ct
-Ct
-Ct
-Lk
-Ct
-Ct
-Ct
-Ct
-Lk
-Ct
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
 Ct
 Ct
 Ct
@@ -65781,7 +66927,7 @@ Ct
 Ct
 Ct
 Ct
-Ct
+zt
 Ct
 Ct
 Ct
@@ -93287,7 +94433,7 @@ kD
 kD
 kD
 kD
-kD
+lF
 kD
 kD
 kD
@@ -94925,13 +96071,13 @@ kD
 kD
 kD
 kD
-Zy
-Zy
 kD
+fY
+Zy
 kD
 Xd
 Xd
-mh
+Xd
 Xd
 ZV
 Ub
@@ -95126,16 +96272,16 @@ lF
 Ya
 ej
 lF
-lF
-lF
-lF
 tE
 tE
-lF
+ZR
+tE
+tE
+tE
 kD
 Xd
-av
-mh
+Xd
+Xd
 Xd
 ZV
 Qc
@@ -95332,14 +96478,14 @@ tE
 tE
 tE
 tE
+kD
+pm
+eh
 tE
-tE
-tE
-lF
 kD
 Xd
-av
-mh
+Xd
+Xd
 Xd
 ZV
 ZV
@@ -95535,15 +96681,15 @@ tE
 tE
 tE
 tE
-tE
-tE
-tE
-tE
 lF
 kD
+su
+eh
+XY
+kD
 Xd
-av
-mh
+Xd
+Xd
 Xd
 ZV
 Ul
@@ -95739,15 +96885,15 @@ tE
 tE
 tE
 tE
-tE
-tE
-tE
-tE
-kP
+lF
+kD
+PA
+lF
+Sy
 kD
 Xd
-av
-mh
+Xd
+Xd
 Xd
 ZV
 fN
@@ -95942,16 +97088,16 @@ lF
 lF
 lF
 tE
-lF
-lF
-lF
-lF
-lF
+tE
 lF
 kD
+LQ
+eh
+cR
+kD
 Xd
-av
-mh
+Xd
+Xd
 Xd
 ZV
 fN
@@ -96146,16 +97292,16 @@ kD
 kD
 lF
 tE
+tE
 lF
 kD
-kD
-kD
-kD
-kD
+sm
+eh
+tE
 kD
 Xd
-av
-mh
+Xd
+Xd
 Xd
 ZV
 fN
@@ -96351,15 +97497,15 @@ kD
 lF
 tE
 tE
-ZR
+tE
+gO
 tE
 tE
 tE
 kD
-nD
 Xd
-av
-mh
+Xd
+Xd
 Xd
 ZV
 fN
@@ -96554,16 +97700,16 @@ qW
 bn
 tE
 tE
+tE
 lF
 kD
-pm
-eh
-tE
 kD
-nD
+kD
+kD
+kD
+kD
 Xd
-av
-mh
+Xd
 Xd
 nD
 nD
@@ -96586,9 +97732,9 @@ nD
 nD
 nD
 nD
-nD
+kD
 dy
-nD
+kD
 rQ
 rQ
 rQ
@@ -96758,46 +97904,46 @@ JR
 kD
 lF
 tE
+tE
 kP
 kD
-su
-eh
-XY
+cy
+HN
+oN
+gd
 kD
-nD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+mL
+kD
+kD
+kD
+kD
+lF
+kD
+kD
+kD
+kD
+kD
 Xd
-av
-mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-av
-av
-nD
-nD
-nD
-nD
-nD
-nD
 WH
 WH
 WH
@@ -96814,9 +97960,9 @@ WH
 WH
 Xd
 Xd
-Xd
-Xd
-Xd
+sn
+RD
+tF
 Xd
 Xd
 av
@@ -96962,45 +98108,45 @@ kD
 kD
 Dm
 tE
-hO
-kD
-PA
+tE
 lF
-Sy
+KE
+qW
+tE
+tE
+tE
+tz
+lL
+zS
+lL
+lL
+lL
+lL
+DG
+lL
+lL
+zS
+Se
+lL
+ds
+lL
+lL
+lL
+lL
+lL
+zS
+lL
+tz
+tE
+lF
+WB
+JP
+lF
+jf
+GX
+GC
+GX
 kD
-nD
-Xd
-Xd
-Hg
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-XD
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-Xd
 Xd
 Xd
 Xd
@@ -97018,9 +98164,9 @@ WH
 WH
 Xd
 Xd
-Xd
-Xd
-Xd
+Ko
+nq
+Vg
 Xd
 Xd
 Xd
@@ -97166,45 +98312,45 @@ HH
 kD
 lF
 tE
+tE
+lF
+KE
+qW
+tE
+Ny
+tE
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+pb
+aC
+lF
+tE
+WB
+lF
+Dy
+Dy
+Dy
+Dy
 lF
 kD
-LQ
-eh
-cR
-kD
-nD
-Xd
-Xd
-Xd
-Xd
-av
-av
-av
-av
-av
-av
-av
-av
-av
-Xd
-av
-av
-av
-av
-av
-Xd
-Xd
-Xd
-Xd
-mh
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-av
-Xd
 Xd
 Xd
 Xd
@@ -97222,9 +98368,9 @@ WH
 WH
 Xd
 Xd
-Xd
-Xd
-Xd
+pw
+St
+yn
 Xd
 Xd
 Xd
@@ -97370,67 +98516,67 @@ qW
 bn
 tE
 tE
+tE
+lF
+KE
+qW
+tE
+tE
+tE
+XD
+me
+sa
+me
+me
+me
+me
+me
+me
+me
+sa
+me
+me
+me
+me
+me
+LL
+me
+me
+sa
+me
+XD
+tE
+lF
+WB
+lF
+Dy
+lF
+lF
+lF
 lF
 kD
-sm
-eh
-tE
-kD
-nD
 Xd
 Xd
 Xd
+WH
+WH
+WH
+WH
+WH
+WH
+WH
+WH
+WH
+WH
+WH
+WH
 Xd
 Xd
-Xd
-je
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-me
-pb
-LL
+Vg
+nq
+Vg
+kq
 av
-CY
-Xd
-Xd
-Xd
-Xd
-mh
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-av
-Xd
-Xd
-Xd
-Xd
-WH
-WH
-WH
-WH
-WH
-WH
-WH
-WH
-WH
-WH
-WH
-WH
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-cJ
 Nh
 av
 Xd
@@ -97575,67 +98721,67 @@ kD
 lF
 tE
 tE
-gO
-tE
-tE
-tE
+hO
 kD
-nD
+dq
+yA
+MI
+YQ
+kD
+iu
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+iu
+kD
+lF
+Dy
+lF
+kD
+lF
+lF
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
 Xd
 Xd
 Xd
-Xd
-Xd
-Xd
-wJ
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-mh
-av
-av
-av
-av
-av
-av
-av
-Xd
-Xd
-Xd
-Xd
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-av
-av
+ct
+Vg
+kW
+kq
+gI
+gI
 av
 Xd
 WH
@@ -97763,7 +98909,7 @@ sQ
 sQ
 sQ
 sQ
-TM
+dN
 TM
 TM
 sQ
@@ -97779,58 +98925,58 @@ kD
 lF
 tE
 lF
+lF
 kD
 kD
 kD
 kD
 kD
-nD
+Rv
+Xd
+pP
 Xd
 Xd
 Xd
-Xd
-Xd
-Xd
-wJ
+av
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 Hg
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+kD
+iK
+vZ
+iK
+kD
+lF
+lF
+WB
+lF
+lF
+dZ
+lF
+lF
+lF
+lF
+WB
+lF
+lF
+lF
+lF
+Ta
+kD
 Xd
 Xd
 Xd
@@ -97984,65 +99130,65 @@ lF
 tE
 kP
 kD
-lF
+kD
 lF
 Bl
 kD
-nD
 Xd
 Xd
+nQ
+av
 Xd
-Xd
-Xd
-Xd
-wJ
+RU
+kE
+LE
 mh
+nD
+nD
+mG
+ur
+nD
+hX
+nD
+ur
+mG
+CZ
+CZ
+CZ
+CZ
+CZ
+CZ
+CZ
+kD
+kD
+kD
+kD
+kD
+AQ
+lF
+Cy
+Dy
+Dy
+Dy
+Dy
+pZ
+Dy
+Dy
+Cy
+Dy
+Dy
+Dy
+Dy
+NI
+kD
+kD
+kD
+kD
+kD
 Xd
 Xd
 Xd
 Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-av
-av
-av
-av
-av
-Nd
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-av
-av
-av
-av
 av
 mN
 Xd
@@ -98192,58 +99338,58 @@ tE
 tE
 yO
 kD
-nD
 Xd
-Xd
-Xd
-Xd
-Xd
+Va
+av
+ae
+ss
+Vz
 Xd
 wJ
 mh
+nD
+nD
+UV
+Dk
+nD
+DS
+nD
+Dk
+UV
+CZ
+CZ
+mj
+SW
+Sx
+CZ
+CZ
+nD
+nD
+nD
+nD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
+Bq
+kD
+kD
+Dy
+Dy
+pZ
+Dy
+lF
+Bq
+Dy
+Dy
+je
+kD
 Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-av
-Xd
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-Xd
-av
 Xd
 Xd
 Xd
@@ -98396,58 +99542,58 @@ eK
 Ku
 oT
 kD
-nD
 Xd
+wt
 Xd
-Xd
-Xd
+JQ
+gS
 Xd
 Xd
 wJ
 mh
+nD
+nD
+mG
+Dk
+KL
+gv
+KL
+Dk
+mG
+CZ
+Jt
+TV
+TV
+TV
+Jt
+CZ
+nD
+CF
+NJ
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+kD
+sM
+VE
+lF
+tv
+kD
+kD
+Bq
+kD
+Bq
+kD
+kD
+Bi
+Dy
+im
+kD
 Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
 Xd
 Xd
 Xd
@@ -98601,7 +99747,7 @@ kD
 kD
 kD
 kD
-Xd
+rd
 Xd
 Xd
 Xd
@@ -98609,50 +99755,50 @@ Xd
 Xd
 wJ
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
 nD
+UV
+Dk
+KL
+gv
+KL
+Dk
+UV
+CZ
+se
+TV
+TV
+TV
+Jt
+CZ
+QN
+La
+QN
+La
+fJ
+nD
+TS
+qa
+Ms
+qa
+Fh
+qW
+lF
+qW
+cy
+kD
+VM
+qW
+pn
+qW
+gX
+kD
+kD
+Bq
+kD
+kD
 nD
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-zj
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-dN
-Xd
 WH
 WH
 WH
@@ -98805,7 +99951,7 @@ Aj
 VQ
 qX
 kD
-Xd
+ax
 Xd
 Xd
 Xd
@@ -98813,50 +99959,50 @@ Xd
 Xd
 wJ
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
 nD
+mG
+Dk
 nD
+DS
 nD
+Dk
+mG
+CZ
+kT
+TV
+TV
+TV
+Pg
+CZ
+uX
+QN
+PL
+QN
+Rc
 nD
+qa
+sA
+sA
+sA
+Fh
+WP
+qW
+lF
+Gk
+Bq
+lF
+qW
+ab
+qW
+lF
+kD
 nD
+IN
+BW
+OT
+vq
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-wA
-av
-av
-Xd
 WH
 WH
 WH
@@ -99017,50 +100163,50 @@ HP
 Xd
 CT
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
 nD
+QV
+Dk
 nD
+HA
 nD
+Dk
+QV
+CZ
+CZ
+TV
+TV
+AG
+CZ
+CZ
+ER
+La
+lD
+La
+fJ
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-Xd
-Xd
 Fo
-av
-av
-Ba
+IE
+dI
+SL
+kD
+kD
+fY
+fY
+kD
+kD
+qE
+qE
+zs
+qE
+qE
+kD
+jL
+RE
+IN
+NB
+IJ
+nD
 WH
 WH
 WH
@@ -99221,50 +100367,50 @@ HP
 hJ
 av
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
 nD
 nD
+RT
 nD
 nD
 nD
+RT
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-Xd
-Xd
-Dk
-av
-av
+CZ
+CZ
 Ba
+Ba
+Ba
+CZ
+LJ
+La
+QN
+nD
+vE
+mM
+nD
+QN
+RE
+QN
+RE
+QN
+RE
+QN
+RE
+QN
+kt
+Br
+tb
+dM
+RE
+Ij
+kt
+RE
+IN
+QU
+EP
+Pe
+nD
 WH
 WH
 WH
@@ -99425,50 +100571,50 @@ HP
 Xd
 av
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
 nD
+FJ
+TV
+TV
+oj
+Fg
+TV
+TV
+Fg
+oj
+TV
+RE
+RE
+tt
+RE
+RE
+RE
+BW
+RE
+RE
+RE
+RE
+QN
+RE
+QN
+RE
+QN
+RE
+QN
+RE
+kt
+oj
+oj
+dM
+tb
+IN
+kt
+IN
+RE
+Hf
+EP
+Ap
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-Xd
-Xd
-On
-av
-av
-Ba
 WH
 WH
 WH
@@ -99629,50 +100775,50 @@ Qm
 Xd
 av
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
 nD
+Fg
+Fg
+oj
+TV
+oj
+Fg
+Fg
+oj
+TV
+oj
+RE
+QN
+QN
+QN
+Fo
+cB
+Fo
+QN
+QN
+QN
+RE
+RE
+QN
+RE
+QN
+RE
+lD
+RE
+QN
+kt
+oj
+zB
+dM
+zY
+DX
+kt
+RE
+IN
+Hf
+EP
+px
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-Xd
-Xd
-pL
-ur
-av
-Xd
 WH
 WH
 WH
@@ -99833,12 +100979,37 @@ YU
 Xd
 av
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+Gx
+Fg
+oj
+TV
+oj
+Fg
+Fg
+oj
+TV
+oj
+RE
+QN
+QN
+QN
+cB
+dL
+cB
+QN
+QN
+QN
+RE
+oj
+Ki
+oj
+oj
+Za
+nD
+wS
+wS
 nD
 nD
 nD
@@ -99846,37 +101017,12 @@ nD
 nD
 nD
 nD
+jL
+RE
+IN
+NB
+OT
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 WH
 WH
 WH
@@ -100037,12 +101183,37 @@ xm
 Xd
 av
 mh
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+wp
+Sq
+gP
+oj
+Fg
+TV
+TV
+Fg
+oj
+TV
+RE
+QN
+QN
+QN
+Fo
+uh
+Fo
+QN
+QN
+QN
+RE
+oj
+oj
+em
+qV
+qV
+FE
+pI
+fG
 nD
 nD
 nD
@@ -100051,35 +101222,10 @@ nD
 nD
 nD
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
+IN
+IL
+IJ
+KM
 nD
 WH
 WH
@@ -100240,38 +101386,38 @@ SY
 Xd
 Xd
 av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
 nD
 nD
 nD
+Jh
 nD
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
+gc
+cB
+cB
+rp
+fA
+lU
+hD
+hD
+hD
+Yu
+YA
+um
+RE
+um
+QM
+RE
+RE
+oj
+Hv
+qV
+em
+qV
+FE
+pI
+Bj
 nD
 nD
 nD
@@ -100444,31 +101590,31 @@ av
 av
 av
 av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+LC
+Yb
+mY
+UH
+nI
+nD
+fb
+La
+La
+wA
+Mg
+lb
+oi
+Uv
+cB
+nD
+nD
+rP
+nD
+rP
 nD
 nD
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
+rP
 nD
 nD
 nD
@@ -100648,34 +101794,34 @@ Xd
 Xd
 Xd
 Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
+pQ
+KR
+aL
+sC
+Ag
 nD
+Vq
+La
+cT
+wM
+wM
+kH
+Uv
+rk
+Yl
 nD
+nX
+bX
+ix
+Ff
+Ai
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
+Ua
+oj
+oj
+oj
+ku
 nD
 WH
 WH
@@ -100852,34 +101998,34 @@ Xd
 Xd
 Xd
 Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
+VC
+Gb
+KR
+Gb
+TE
 nD
+Nr
+La
+lb
+rk
+wA
+Uv
+rk
+wM
+zQ
 nD
+gW
+Fg
+DZ
+ke
+Bm
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
+Mx
+oj
+oj
+oj
+Wh
 nD
 WH
 WH
@@ -101056,33 +102202,33 @@ Xd
 Xd
 Xd
 Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
 nD
+CE
+dv
+nv
+co
+PQ
 nD
+wT
+Ow
+Jk
+wy
+rk
+AU
+Vu
+rk
+Dw
 nD
+qs
+OH
+hI
+on
+uI
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
+Gv
+oj
+cW
+IW
 nD
 nD
 WH
@@ -101260,13 +102406,11 @@ Xd
 Xd
 Xd
 Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+MJ
+MJ
+MJ
 nD
 nD
 nD
@@ -101280,7 +102424,9 @@ nD
 nD
 nD
 nD
+MJ
 nD
+CJ
 nD
 nD
 nD

--- a/_maps/map_files/city13_prison/city13_prison.dmm
+++ b/_maps/map_files/city13_prison/city13_prison.dmm
@@ -4,17 +4,23 @@
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands/shop)
 "ab" = (
-/obj/machinery/button/door/directional/east,
-/turf/open/floor/plating/indoor/metal/combine/alt2,
-/area/halflife/indoors/prison/security)
+/obj/structure/closet/crate/halflife{
+	name = "footlocker";
+	desc = "A rectangular steel locker, traditionally mounted at the end of beds."
+	},
+/turf/open/floor/plating/indoor/grooved2,
+/area/halflife/indoors/prison)
 "ac" = (
 /obj/structure/halflife/rug/rubber,
 /turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security)
 "ae" = (
+/obj/structure/halflife/road_barrier/concrete{
+	dir = 4
+	},
 /obj/item/clothing/suit/armor/vest/press{
 	name = "United Nations armor vest";
-	desc = "A blue armor vest used to distinguish non-combatant \PEACEKEEPER\ UN members, though this is only bound to put a bigger target on your back nowadays."
+	desc = "A blue armor vest used to distinguish non-combatant PEACEKEEPER UN members, though this is only bound to put a bigger target on your back nowadays."
 	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/maintenance)
@@ -145,25 +151,8 @@
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison/infirmary)
 "aC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 8
-	},
-/obj/structure/railing/halflife/full{
-	dir = 8
-	},
-/obj/structure/railing/halflife/full{
-	dir = 4
-	},
-/turf/open/floor/plating/indoor/metal/smooth,
+/obj/machinery/button/door/directional/east,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security)
 "aD" = (
 /obj/structure/table/halflife/wood/constructed/cobbled,
@@ -752,13 +741,6 @@
 /obj/effect/landmark/navigate_destination/halflife/mines,
 /turf/open/floor/plating/indoor/checkered,
 /area/halflife/indoors/prison/cells)
-"ds" = (
-/obj/machinery/conveyor/auto,
-/obj/machinery/camera/directional/east{
-	c_tag = "High-Sec Motorway B"
-	},
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
 "dt" = (
 /obj/structure/table/halflife/no_smooth/wood/stand,
 /turf/open/floor/plating/indoor/tile/green,
@@ -1374,8 +1356,9 @@
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/prison)
 "gd" = (
-/obj/structure/fluff/wallsign/directional/south,
-/obj/structure/closet/crate/bin,
+/obj/structure/chair/halflife/metal/blue{
+	dir = 4\
+	},
 /turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security)
 "ge" = (
@@ -1535,11 +1518,6 @@
 /obj/structure/flora/tree/halflife/pine/style_random,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
-"gS" = (
-/obj/item/reagent_containers/cup/soda_cans/breenwater/fuel,
-/obj/structure/halflife/road_barrier/concrete,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
 "gT" = (
 /obj/machinery/door/unpowered/halflife/wood/white{
 	keylock = 1;
@@ -1704,11 +1682,6 @@
 /obj/item/trash/flare,
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest)
-"hG" = (
-/obj/structure/halflife/storage/large/shelf,
-/obj/effect/spawner/random/halflife/loot,
-/turf/open/floor/plating/indoor/tile/black,
-/area/halflife/indoors/prison/maintenance)
 "hH" = (
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
 /turf/open/floor/plating/indoor/metal/smooth,
@@ -1717,10 +1690,6 @@
 /obj/structure/weightmachine,
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/prison)
-"hJ" = (
-/obj/machinery/door/unpowered/halflife/seethrough/grate,
-/turf/open/floor/plating/indoor/tile/black,
-/area/halflife/indoors/prison/maintenance)
 "hK" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
 	pixel_x = 2;
@@ -1853,10 +1822,6 @@
 /mob/living/basic/halflife/headcrab,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
-"iu" = (
-/obj/structure/fluff/wallsign/directional/north,
-/turf/closed/wall/halflife/metal,
-/area/halflife/indoors/prison/security)
 "iw" = (
 /turf/closed/indestructible/rock,
 /area/halflife/indoors/sewer/outlandscave)
@@ -1911,11 +1876,10 @@
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/bunker)
 "iK" = (
-/obj/structure/chair/halflife/metal/blue{
-	dir = 8
-	},
-/turf/open/floor/plating/indoor/metal/combine,
-/area/halflife/indoors/prison/security)
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "iL" = (
 /obj/effect/spawner/random/halflife/loot,
 /turf/open/floor/plating/ground/rockunder,
@@ -1997,13 +1961,6 @@
 "je" = (
 /obj/structure/halflife/trash/bricks,
 /turf/open/floor/plating/indoor/metal/industrial,
-/area/halflife/indoors/prison/security)
-"jf" = (
-/obj/structure/closet/secure_closet/halflife,
-/obj/machinery/camera/directional/east{
-	c_tag = "High-Sec Transfer Room"
-	},
-/turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
 "jg" = (
 /obj/structure/table/halflife/metal/alt,
@@ -2307,11 +2264,6 @@
 "kD" = (
 /turf/closed/wall/halflife/metal,
 /area/halflife/indoors/prison/security)
-"kE" = (
-/obj/item/stack/sheet/scrap_metal,
-/obj/structure/barricade/wooden/solid,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
 "kG" = (
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest/prison_yard)
@@ -2566,7 +2518,9 @@
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison/gym)
 "lL" = (
-/obj/machinery/conveyor/auto,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security-To-High-Sec Transfer"
+	},
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
 "lM" = (
@@ -2640,9 +2594,7 @@
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/mining)
 "me" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
+/obj/machinery/combine_walllight/directional/west,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
 "mf" = (
@@ -2775,12 +2727,10 @@
 /turf/open/floor/plating/indoor/metal/pipe,
 /area/halflife/indoors/sewer)
 "mG" = (
-/obj/structure/closet/crate/halflife{
-	name = "footlocker";
-	desc = "A rectangular steel locker, traditionally mounted at the end of beds."
-	},
-/turf/open/floor/plating/indoor/grooved2,
-/area/halflife/indoors/prison)
+/obj/structure/halflife/trash/garbage,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "mH" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/halflife/loot/trash,
@@ -2800,9 +2750,11 @@
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/bunker)
 "mL" = (
-/obj/structure/fluff/wallsign/directional/south,
-/turf/closed/wall/halflife/metal,
-/area/halflife/indoors/prison/security)
+/obj/item/rack_parts,
+/obj/effect/spawner/random/halflife/loot/gun_frame,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "mM" = (
 /obj/structure/window/fulltile/halflife/nosmooth/reinforced{
 	dir = 4
@@ -2956,6 +2908,12 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/plating/ground/rockunder,
 /area/halflife/indoors/sewer/cave)
+"ns" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "nt" = (
 /obj/structure/table/halflife/wood/constructed/cobbled,
 /obj/effect/spawner/random/halflife/loot/uncommon,
@@ -3052,9 +3010,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/halflife/outdoors/forest)
 "nQ" = (
-/obj/item/storage/box/halflife/ration/worstration,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/table/halflife/no_smooth/wood/stand,
+/obj/item/restraints/handcuffs,
+/obj/item/taperecorder,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "nR" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/plating/indoor/metal/combine,
@@ -3367,23 +3327,9 @@
 /turf/open/floor/plating/indoor/tile/kitchen,
 /area/halflife/indoors/prison/cafeteria)
 "pb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/arrow_ccw{
-	dir = 8
-	},
-/obj/structure/railing/halflife/full{
-	dir = 4
-	},
-/obj/structure/railing/halflife/full{
-	dir = 8
+/obj/structure/halflife/pot/plant,
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Entrance"
 	},
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
@@ -3484,6 +3430,12 @@
 	},
 /turf/open/floor/plating/indoor/woodc/mosaic,
 /area/halflife/indoors/outlands/shop)
+"pv" = (
+/obj/machinery/turnstile/brig/halflife/forcefield/civilprotection/nodirectional{
+	dir = 8
+	},
+/turf/closed/wall/halflife/metal,
+/area/halflife/indoors/prison/security)
 "pw" = (
 /turf/open/floor/plating/indoor/carpet/blue,
 /area/halflife/indoors/prison/maintenance)
@@ -3719,7 +3671,12 @@
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands/shop)
 "qw" = (
-/obj/structure/table/halflife/metal/grate,
+/obj/structure/halflife/road_barrier/concrete{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison/maintenance)
 "qx" = (
@@ -4115,13 +4072,6 @@
 /obj/structure/halflife/rug,
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/security/warden)
-"sa" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/machinery/combine_walllight/directional/west,
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
 "sb" = (
 /obj/structure/table/halflife/metal/grate,
 /obj/item/stamp{
@@ -4212,9 +4162,9 @@
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/security)
 "ss" = (
-/obj/structure/halflife/road_barrier/concrete,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/closet/secure_closet/halflife,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "st" = (
 /obj/structure/flora/rock/style_random,
 /turf/open/floor/plating/ground/rockunder,
@@ -4483,11 +4433,8 @@
 /turf/open/floor/plating/indoor/woodc/fancy,
 /area/halflife/indoors/prison/infirmary)
 "tz" = (
-/obj/machinery/conveyor/auto,
-/obj/machinery/turnstile/brig/halflife/forcefield/civilprotection/nodirectional{
-	dir = 1
-	},
-/turf/open/floor/plating/indoor/metal/smooth,
+/obj/structure/closet/secure_closet/halflife,
+/turf/closed/wall/halflife/metal,
 /area/halflife/indoors/prison/security)
 "tA" = (
 /obj/structure/halflife/pipes/horizontal/end,
@@ -4649,7 +4596,7 @@
 /area/halflife/indoors/prison/factory)
 "um" = (
 /obj/structure/barricade/wooden/solid,
-/turf/open/floor/plating/indoor/tile/black,
+/turf/open/floor/plating/indoor/tile/navy,
 /area/halflife/indoors/prison)
 "un" = (
 /obj/machinery/light/small/directional/north,
@@ -5063,9 +5010,8 @@
 /obj/structure/chair/halflife/metal/blue{
 	dir = 8
 	},
-/obj/item/restraints/handcuffs,
 /obj/machinery/combine_walllight/directional/west,
-/turf/open/floor/plating/indoor/metal/combine,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/halflife/indoors/prison/security)
 "wa" = (
 /turf/closed/wall/halflife/wood,
@@ -5149,6 +5095,9 @@
 "wp" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/sign/warning/biohazard/directional/east,
+/obj/machinery/camera/directional/south{
+	c_tag = "High-Sec Hall"
+	},
 /turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison)
 "wr" = (
@@ -5231,9 +5180,11 @@
 /turf/open/halflife/water/sludge/medium,
 /area/halflife/indoors/sewer)
 "wJ" = (
-/obj/structure/halflife/pipes/horizontal,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/machinery/door/unpowered/halflife/metal{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "wK" = (
 /obj/structure/razorwire{
 	dir = 4
@@ -5362,10 +5313,13 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security/armory)
 "xm" = (
-/obj/structure/closet/halflife,
-/obj/effect/spawner/random/halflife/loot,
-/turf/open/floor/plating/indoor/tile/black,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/chair/halflife/metal/blue{
+	dir = 1
+	},
+/obj/machinery/combine_walllight/directional/west,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "xn" = (
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands/shop)
@@ -5956,11 +5910,6 @@
 /obj/structure/rustic_extractor,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
-"zS" = (
-/obj/machinery/conveyor/auto,
-/obj/machinery/combine_walllight/directional/east,
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
 "zT" = (
 /obj/machinery/turnstile/brig/halflife/forcefield/loyalists{
 	dir = 4;
@@ -6465,11 +6414,6 @@
 	},
 /turf/open/floor/plating/indoor/woodc,
 /area/halflife/indoors/prison/commissary)
-"Cg" = (
-/obj/structure/table/halflife/metal/grate,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
 "Ch" = (
 /turf/open/floor/plating/indoor/metal/pipe/intersection{
 	dir = 4
@@ -6643,8 +6587,9 @@
 /turf/open/floor/plating/indoor/trainfloor,
 /area/halflife/indoors/prison/intake)
 "CT" = (
-/obj/structure/halflife/pipes/horizontal/end,
-/turf/open/floor/plating/indoor/metal/plate,
+/obj/structure/table/halflife/metal/constructed/cobbled,
+/obj/item/storage/box/halflife/ration/worstration,
+/turf/closed/wall/halflife/concrete/bunker,
 /area/halflife/indoors/prison/maintenance)
 "CU" = (
 /obj/structure/halflife/pipes/piped,
@@ -6823,13 +6768,6 @@
 /obj/structure/table/halflife/wood/constructed/cobbled,
 /turf/open/floor/plating/ground/grass,
 /area/halflife/outdoors/forest)
-"DG" = (
-/obj/machinery/conveyor/auto,
-/obj/machinery/camera/directional/east{
-	c_tag = "High-Sec Motorway A"
-	},
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
 "DH" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small/directional/west,
@@ -7517,12 +7455,6 @@
 /obj/structure/closet/halflife,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/sewer)
-"Gx" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "High-Sec Hall"
-	},
-/turf/open/floor/plating/indoor/concrete,
-/area/halflife/indoors/prison)
 "Gy" = (
 /obj/structure/halflife/leaves,
 /turf/open/floor/plating/ground/grass,
@@ -7542,11 +7474,6 @@
 /obj/item/hl2key/maint,
 /obj/item/hl2key/maint,
 /obj/item/hl2key/maint,
-/turf/open/floor/plating/indoor/metal/combine,
-/area/halflife/indoors/prison/security)
-"GC" = (
-/obj/structure/closet/secure_closet/halflife,
-/obj/machinery/combine_walllight/directional/east,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
 "GD" = (
@@ -7639,6 +7566,8 @@
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/halflife/indoors/prison/factory)
 "GX" = (
+/obj/structure/bed/halflife/bedframe/wire,
+/obj/structure/bed/halflife/mattress/stained,
 /obj/structure/closet/secure_closet/halflife,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
@@ -7677,11 +7606,6 @@
 	},
 /turf/open/floor/plating/indoor/tile,
 /area/halflife/indoors/prison)
-"Hg" = (
-/turf/open/floor/plating/indoor/metal/pipe/corner{
-	dir = 8
-	},
-/area/halflife/indoors/prison/security)
 "Hh" = (
 /obj/item/reagent_containers/syringe,
 /obj/machinery/chem_mass_spec,
@@ -8737,10 +8661,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
-"LE" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
 "LF" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/utility/radiation/cleanup,
@@ -8774,13 +8694,6 @@
 /obj/effect/turf_decal/halflife/covering/tiles/white,
 /turf/closed/wall/halflife/brick/grey,
 /area/halflife/indoors/prison/infirmary)
-"LL" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
 "LM" = (
 /mob/living/basic/halflife/grub,
 /turf/open/floor/plating/ground/rockunder,
@@ -9248,13 +9161,6 @@
 	},
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/prison/engineering)
-"Ny" = (
-/obj/structure/signpost{
-	desc = "Please keep all prisoners within reach when using the motorway, and exit on in orderly fashion. If transporting multiple prisoners, wait a small duration of time before following behing a convoy to prevent jams when the motorway is being exited.";
-	name = "High-Security Transport Disclaimer"
-	},
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
 "Nz" = (
 /obj/machinery/door/unpowered/halflife/seethrough/bar{
 	keylock = 1;
@@ -9762,6 +9668,7 @@
 /area/halflife/indoors/bunker)
 "PA" = (
 /obj/machinery/vending/breenwater,
+/obj/structure/closet/secure_closet/halflife,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
 "PB" = (
@@ -9927,10 +9834,6 @@
 /obj/structure/window/fulltile/halflife/nosmooth/reinforced,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/prison)
-"Qm" = (
-/obj/effect/landmark/destabilizer,
-/turf/open/floor/plating/indoor/tile/black,
-/area/halflife/indoors/prison/maintenance)
 "Qn" = (
 /obj/machinery/door/unpowered/halflife/seethrough/metal{
 	keylock = 1;
@@ -10189,9 +10092,6 @@
 	},
 /turf/open/floor/plating/indoor/concrete/sewer,
 /area/halflife/indoors/sewer)
-"Rv" = (
-/turf/closed/wall/halflife/metal,
-/area/halflife/indoors/prison/maintenance)
 "Rw" = (
 /obj/structure/table/halflife/wood/constructed,
 /obj/item/reagent_containers/pill/patch/medkit/vial,
@@ -10291,11 +10191,11 @@
 /turf/open/floor/plating/indoor/grooved2,
 /area/halflife/indoors/prison)
 "RU" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/halflife/road_barrier{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tile/navy,
+/area/halflife/indoors/prison)
 "RV" = (
 /obj/machinery/camera{
 	c_tag = "Labor Union";
@@ -10336,11 +10236,6 @@
 	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/halflife/indoors/prison)
-"Se" = (
-/obj/machinery/conveyor/auto,
-/obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
 "Sf" = (
 /obj/effect/spawner/random/halflife/loot/heal,
 /turf/open/floor/plating/ground/rockunder,
@@ -10449,7 +10344,9 @@
 /area/halflife/indoors/prison/cargo)
 "Sx" = (
 /obj/structure/table/halflife/metal/grate,
-/obj/structure/halflife/trash/garbage,
+/obj/structure/bedsheetbin/empty/basket{
+	desc = "Devoid of sheets, looks like you won't be getting a comfy rest."
+	},
 /turf/open/floor/plating/indoor/concrete/small,
 /area/halflife/indoors/prison)
 "Sy" = (
@@ -10584,11 +10481,10 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/prison/security)
 "SY" = (
-/obj/machinery/door/unpowered/halflife/seethrough/grate{
-	dir = 4
-	},
-/turf/open/floor/plating/indoor/tile/black,
-/area/halflife/indoors/prison/maintenance)
+/obj/machinery/computer/records/security,
+/obj/machinery/combine_walllight/directional/west,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "SZ" = (
 /obj/structure/chair/halflife/metal/folding{
 	dir = 8
@@ -11018,11 +10914,6 @@
 "UZ" = (
 /turf/open/floor/plating/indoor/trainfloor,
 /area/halflife/indoors/prison)
-"Va" = (
-/obj/item/rack_parts,
-/obj/effect/spawner/random/halflife/loot/gun_frame,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/halflife/indoors/prison/maintenance)
 "Vb" = (
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plating/indoor/concrete,
@@ -11621,12 +11512,13 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/halflife/indoors/sewer/cave)
 "XD" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
+/obj/item/stack/sheet/scrap_metal,
+/obj/structure/barricade/wooden/solid,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/obj/machinery/turnstile/brig/halflife/forcefield/civilprotection/nodirectional,
-/turf/open/floor/plating/indoor/metal/smooth,
-/area/halflife/indoors/prison/security)
+/turf/open/floor/plating/indoor/metal/plate,
+/area/halflife/indoors/prison/maintenance)
 "XE" = (
 /obj/effect/spawner/random/halflife/loot/trash,
 /turf/open/floor/plating/indoor/grooved2,
@@ -11649,9 +11541,12 @@
 /turf/open/floor/plating/indoor/metal/grate/border,
 /area/halflife/indoors/sewer)
 "XI" = (
-/obj/structure/halflife/storage/large/shelf,
-/turf/open/floor/plating/indoor/tile/black,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/halflife/sign/combine/prison{
+	name = "combine 'Nowy Jutro Permament Residence' sign";
+	desc = "A sign marking the area ahead as the Permament Residence sector of Nowy Jutro. Seems better then solitary, at the very least."
+	},
+/turf/closed/wall/halflife/metal,
+/area/halflife/indoors/prison/security)
 "XK" = (
 /obj/structure/halflife/fence/vertical/wire/east/barb,
 /turf/open/floor/plating/ground/dirt,
@@ -11787,7 +11682,7 @@
 /area/halflife/indoors/laborunion)
 "Yu" = (
 /obj/structure/halflife/road_barrier/concrete/alt,
-/turf/open/floor/plating/indoor/tile/black,
+/turf/open/floor/plating/indoor/tile/navy,
 /area/halflife/indoors/prison)
 "Yv" = (
 /obj/structure/halflife/trash/papers/one{
@@ -11912,8 +11807,10 @@
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/halflife/indoors/outlands)
 "YQ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating/indoor/metal/combine/alt2,
+/obj/machinery/camera/directional/east{
+	c_tag = "High-Sec Interrogation"
+	},
+/turf/open/floor/plating/indoor/metal/industrial,
 /area/halflife/indoors/prison/security)
 "YR" = (
 /obj/machinery/light/small/directional/west,
@@ -11928,9 +11825,11 @@
 	},
 /area/halflife/outdoors/forest)
 "YU" = (
-/obj/structure/closet/halflife,
-/turf/open/floor/plating/indoor/tile/black,
-/area/halflife/indoors/prison/maintenance)
+/obj/structure/chair/halflife/metal/blue{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/combine/alt2,
+/area/halflife/indoors/prison/security)
 "YV" = (
 /turf/open/floor/plating/indoor/woodc,
 /area/halflife/outdoors/forest/water)
@@ -94435,7 +94334,7 @@ kD
 kD
 lF
 kD
-kD
+tz
 kD
 kD
 Xd
@@ -94639,7 +94538,7 @@ lF
 Ya
 lF
 lF
-OG
+GX
 kD
 kD
 Xd
@@ -95872,7 +95771,7 @@ av
 av
 av
 Bp
-av
+ns
 mh
 Xd
 ZV
@@ -96076,7 +95975,7 @@ fY
 Zy
 kD
 Xd
-Xd
+XD
 Xd
 Xd
 ZV
@@ -96280,8 +96179,8 @@ tE
 tE
 kD
 Xd
-Xd
-Xd
+qw
+ae
 Xd
 ZV
 Qc
@@ -96478,15 +96377,15 @@ tE
 tE
 tE
 tE
-kD
+tz
 pm
 eh
 tE
 kD
-Xd
-Xd
-Xd
-Xd
+mG
+iK
+Os
+av
 ZV
 ZV
 mD
@@ -96689,8 +96588,8 @@ XY
 kD
 Xd
 Xd
-Xd
-Xd
+pP
+av
 ZV
 Ul
 mD
@@ -96891,10 +96790,10 @@ PA
 lF
 Sy
 kD
-Xd
-Xd
-Xd
-Xd
+mL
+av
+av
+Vz
 ZV
 fN
 mD
@@ -97095,9 +96994,9 @@ LQ
 eh
 cR
 kD
+wt
 Xd
-Xd
-Xd
+CT
 Xd
 ZV
 fN
@@ -97299,7 +97198,7 @@ sm
 eh
 tE
 kD
-Xd
+rd
 Xd
 Xd
 Xd
@@ -97503,7 +97402,7 @@ tE
 tE
 tE
 kD
-Xd
+ax
 Xd
 Xd
 Xd
@@ -97703,7 +97602,7 @@ tE
 tE
 lF
 kD
-kD
+XI
 kD
 kD
 kD
@@ -97910,7 +97809,7 @@ kD
 cy
 HN
 oN
-gd
+lF
 kD
 kD
 kD
@@ -97920,21 +97819,21 @@ kD
 kD
 kD
 kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-mL
-kD
-kD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 kD
 kD
 lF
@@ -98115,37 +98014,37 @@ qW
 tE
 tE
 tE
-tz
-lL
-zS
-lL
-lL
-lL
-lL
-DG
-lL
-lL
-zS
-Se
-lL
-ds
-lL
-lL
-lL
-lL
-lL
-zS
-lL
-tz
-tE
 lF
-WB
+tE
+tE
+tE
+tE
+lL
+lF
+dq
+kD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+kD
 JP
 lF
-jf
-GX
-GC
-GX
+lF
+AQ
+lF
+lF
 kD
 Xd
 Xd
@@ -98317,38 +98216,38 @@ lF
 KE
 qW
 tE
-Ny
 tE
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-pb
-aC
-lF
 tE
-WB
-lF
-Dy
-Dy
-Dy
-Dy
+tE
+tE
+tE
+tE
+tE
+tE
+tE
+cy
+kD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+kD
+kD
+wJ
+kD
+kD
+qW
 lF
 kD
 Xd
@@ -98523,36 +98422,36 @@ qW
 tE
 tE
 tE
-XD
-me
-sa
-me
-me
-me
-me
-me
-me
-me
-sa
-me
-me
-me
-me
-me
-LL
-me
-me
-sa
-me
-XD
+lF
 tE
-lF
-WB
-lF
+tE
+me
+tE
+tE
+tE
+cy
+kD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+kD
 Dy
-lF
-lF
-lF
+qW
+YQ
+kD
+qW
 lF
 kD
 Xd
@@ -98726,37 +98625,37 @@ kD
 dq
 yA
 MI
-YQ
-kD
-iu
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-kD
-iu
-kD
-lF
-Dy
 lF
 kD
-lF
+kD
+kD
+kD
+pv
+pv
+pv
+kD
+kD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+kD
+gd
+nQ
+qW
+bn
+qW
 lF
 kD
 kD
@@ -98931,36 +98830,36 @@ kD
 kD
 kD
 kD
-Rv
-Xd
-pP
-Xd
-Xd
-Xd
-av
-mh
+bD
 nD
 nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-nD
-Hg
-kD
-iK
-vZ
-iK
 kD
 lF
+lF
+lF
+kD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+kD
+Dy
+vZ
+Dy
+kD
+qW
 lF
 WB
 lF
@@ -99134,24 +99033,24 @@ kD
 lF
 Bl
 kD
-Xd
-Xd
-nQ
-av
-Xd
-RU
-kE
-LE
-mh
 nD
 nD
-mG
+nD
+kD
+kD
+tE
+tE
+tE
+kD
+nD
+nD
+ab
 ur
 nD
 hX
 nD
 ur
-mG
+ab
 CZ
 CZ
 CZ
@@ -99164,7 +99063,7 @@ kD
 kD
 kD
 kD
-AQ
+Gk
 lF
 Cy
 Dy
@@ -99338,16 +99237,16 @@ tE
 tE
 yO
 kD
-Xd
-Va
-av
-ae
-ss
-Vz
-Xd
-wJ
-mh
 nD
+nD
+nD
+kD
+ss
+tE
+tE
+tE
+kD
+kD
 nD
 UV
 Dk
@@ -99542,24 +99441,24 @@ eK
 Ku
 oT
 kD
-Xd
-wt
-Xd
-JQ
-gS
-Xd
-Xd
-wJ
-mh
 nD
 nD
-mG
+nD
+kD
+ss
+tE
+tE
+tE
+YU
+kD
+nD
+ab
 Dk
 KL
 gv
 KL
 Dk
-mG
+ab
 CZ
 Jt
 TV
@@ -99747,15 +99646,15 @@ kD
 kD
 kD
 kD
-rd
-Xd
-Xd
-Xd
-Xd
-Xd
-wJ
-mh
 nD
+nD
+kD
+ss
+tE
+tE
+tE
+xm
+kD
 nD
 UV
 Dk
@@ -99951,23 +99850,23 @@ Aj
 VQ
 qX
 kD
-ax
-Xd
-Xd
-Xd
-Xd
-Xd
-wJ
-mh
 nD
 nD
-mG
+kD
+ss
+tE
+lF
+tE
+kD
+kD
+nD
+ab
 Dk
 nD
 DS
 nD
 Dk
-mG
+ab
 CZ
 kT
 TV
@@ -99993,7 +99892,7 @@ Gk
 Bq
 lF
 qW
-ab
+aC
 qW
 lF
 kD
@@ -100155,14 +100054,14 @@ VQ
 VQ
 Nj
 kD
-Xd
-Xd
-hG
-HP
-HP
-Xd
-CT
-mh
+nD
+nD
+kD
+kD
+lF
+SY
+lF
+kD
 nD
 nD
 QV
@@ -100359,14 +100258,14 @@ VQ
 VQ
 vN
 kD
-Xd
-Xd
-HP
-HP
-HP
-hJ
-av
-mh
+nD
+nD
+nD
+kD
+Bq
+kD
+Bq
+kD
 nD
 nD
 nD
@@ -100563,16 +100462,16 @@ VQ
 VQ
 Ka
 kD
-Xd
-Xd
-HP
-HP
-HP
-Xd
-av
-mh
 nD
 nD
+nD
+kD
+tE
+pb
+lF
+kD
+kD
+kD
 FJ
 TV
 TV
@@ -100584,15 +100483,15 @@ Fg
 oj
 TV
 RE
-RE
+QN
 tt
+QN
 RE
-RE
-RE
+QN
 BW
+QN
 RE
-RE
-RE
+QN
 RE
 QN
 RE
@@ -100767,16 +100666,16 @@ ZN
 VQ
 Kv
 kD
-Xd
-Xd
-HP
-HP
-Qm
-Xd
-av
-mh
 nD
 nD
+nD
+kD
+lF
+tE
+lF
+lF
+lF
+KE
 Fg
 Fg
 oj
@@ -100787,17 +100686,17 @@ Fg
 oj
 TV
 oj
+QN
 RE
 QN
-QN
-QN
+RE
 Fo
 cB
 Fo
-QN
-QN
+RE
 QN
 RE
+QN
 RE
 QN
 RE
@@ -100971,17 +100870,17 @@ kD
 kD
 kD
 kD
-Xd
-Xd
-XI
-HP
-YU
-Xd
-av
-mh
 nD
 nD
-Gx
+nD
+kD
+lF
+me
+tE
+me
+lF
+KE
+Fg
 Fg
 oj
 TV
@@ -100993,16 +100892,16 @@ TV
 oj
 RE
 QN
-QN
+RE
 QN
 cB
 dL
 cB
 QN
-QN
+RE
 QN
 RE
-oj
+QN
 Ki
 oj
 oj
@@ -101164,27 +101063,27 @@ ou
 nD
 nD
 nD
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-HP
-HP
-xm
-Xd
-av
-mh
 nD
 nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+kD
+kD
+kD
+kD
+kD
+kD
+kD
 wp
 Sq
 gP
@@ -101195,17 +101094,17 @@ TV
 Fg
 oj
 TV
+QN
 RE
 QN
-QN
-QN
+RE
 Fo
 uh
 Fo
-QN
-QN
+RE
 QN
 RE
+QN
 oj
 oj
 em
@@ -101368,24 +101267,24 @@ ou
 nD
 nD
 nD
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-SY
-Xd
-Xd
-av
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 nD
 nD
 nD
@@ -101400,7 +101299,7 @@ rp
 fA
 lU
 hD
-hD
+RU
 hD
 Yu
 YA
@@ -101408,7 +101307,7 @@ um
 RE
 um
 QM
-RE
+QN
 RE
 oj
 Hv
@@ -101572,24 +101471,24 @@ ou
 nD
 nD
 nD
-av
-Xd
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
-av
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 nD
 LC
 Yb
@@ -101774,26 +101673,26 @@ QZ
 QZ
 QZ
 QZ
-Xd
-Xd
-av
-OV
-av
-av
-Xd
-fq
-fq
-fq
-fq
-fq
-fq
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 nD
 pQ
 KR
@@ -101978,26 +101877,26 @@ ZO
 ZO
 WE
 QZ
-Cg
-av
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 nD
 VC
 Gb
@@ -102182,26 +102081,26 @@ ZO
 ZO
 FI
 QZ
-av
-av
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 nD
 CE
 dv
@@ -102386,26 +102285,26 @@ ZO
 ZO
 lX
 QZ
-qw
-av
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 nD
 nD
 MJ
@@ -102592,15 +102491,15 @@ QZ
 QZ
 QZ
 QZ
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 WH
 WH
 WH
@@ -102796,15 +102695,15 @@ UG
 vF
 ny
 QZ
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 WH
 WH
 WH
@@ -103000,15 +102899,15 @@ UG
 UG
 ny
 QZ
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 WH
 WH
 WH
@@ -103200,19 +103099,19 @@ UG
 QZ
 QZ
 QZ
-we
 QZ
 QZ
 QZ
-av
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+QZ
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 WH
 WH
 WH
@@ -103402,15 +103301,15 @@ LK
 ye
 UG
 QZ
-Xd
-Xd
-av
-av
-av
-av
-av
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 WH
 WH
 WH
@@ -103606,15 +103505,15 @@ LK
 SF
 UG
 QZ
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
-Xd
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
+nD
 WH
 WH
 WH
@@ -103810,9 +103709,9 @@ LK
 kf
 kf
 QZ
-Xd
-Xd
-Xd
+nD
+nD
+nD
 WH
 WH
 WH


### PR DESCRIPTION
## About The Pull Request

Adds the Perma area to the prison, with a visitation booth to be opened during non-work hours to encourage interactions between standard prisoners and high-security inmates. Additionally, the sector itself acts as an alternative that isn't More Brainwashing, Stalkerization, or complete disconnect from the round with solitary confinement- and has some unique design pieces, like the abandoned gym or quarantine cell. Theres also 2 new maint ruins with their own loot.

## Why It's Good For The Game

Holy shit is it boring to be in solitary forever. This replaces the 100% disconnect to the round to something more akin to normal SS13, Perma, with visitation added to help further dissuade ghosting or giving up and watching youtube till you get out or something. Theres also some chances to escape, with some security flaws- or just give up and earn your drink.
<img width="548" height="966" alt="image" src="https://github.com/user-attachments/assets/acea07ef-8554-4082-b7b5-a63d75b8e3f9" />

## Changelog
:cl:
map: perma is here
/:cl:

