### PR TITLE
OSP loadout

### DIFF
--- a/_maps/map_files/deployment_intruder/deployment_intruder.dmm
+++ b/_maps/map_files/deployment_intruder/deployment_intruder.dmm
@@ -53,6 +53,10 @@
 /obj/effect/landmark/navigate_destination/halflife/intruder/storagea,
 /turf/open/floor/plating/indoor/concrete,
 /area/halflife/indoors/intruder/storagea)
+"aW" = (
+/obj/effect/landmark/intruder_guncase,
+/turf/open/floor/plating/indoor/tile/green,
+/area/halflife/indoors/intruder/lockerroom)
 "aY" = (
 /obj/structure/halflife/processor/console,
 /turf/open/floor/plating/indoor/sterilesquares,
@@ -463,6 +467,10 @@
 	},
 /turf/closed/wall/halflife/concrete/bunker,
 /area/halflife/indoors/intruder/lab)
+"kc" = (
+/obj/effect/landmark/intruder_guncase,
+/turf/open/floor/plating/indoor/tile/green,
+/area/halflife/indoors/intruder/lab)
 "kg" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/indoor/concrete,
@@ -726,6 +734,10 @@
 	},
 /turf/open/floor/plating/indoor/carpet/green,
 /area/halflife/indoors/intruder/entrance)
+"oM" = (
+/obj/effect/landmark/intruder_guncase,
+/turf/open/floor/plating/indoor/concrete/small,
+/area/halflife/indoors/intruder/storageb)
 "oN" = (
 /turf/open/floor/plating/indoor/metal/pipe/intersection,
 /area/halflife/indoors/intruder/storagec)
@@ -747,6 +759,7 @@
 /obj/structure/sign/poster/halflife/combine/four{
 	pixel_y = 32
 	},
+/obj/effect/landmark/intruder_guncase,
 /turf/open/floor/plating/indoor/tile/black,
 /area/halflife/indoors/intruder/entrance)
 "pm" = (
@@ -1032,6 +1045,7 @@
 /turf/open/floor/plating/indoor/checkered,
 /area/halflife/indoors/intruder/cafeteria)
 "wf" = (
+/obj/effect/landmark/intruder_guncase,
 /turf/open/floor/plating/indoor/metal/grate,
 /area/halflife/indoors/intruder/barracks)
 "wj" = (
@@ -1131,6 +1145,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/halflife/indoors/intruder/lab)
+"xV" = (
+/obj/effect/landmark/intruder_guncase,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/halflife/indoors/intruder/office)
 "ya" = (
 /obj/structure/halflife/pallet/stack,
 /turf/open/floor/plating/indoor/metal/grate,
@@ -1675,6 +1693,10 @@
 /obj/effect/koth_grace_field,
 /turf/open/floor/plating/indoor/concrete/bricks,
 /area/halflife/indoors/intruder/barracks)
+"Nx" = (
+/obj/effect/landmark/intruder_guncase,
+/turf/open/floor/plating/indoor/woodc,
+/area/halflife/indoors/intruder/office)
 "Nz" = (
 /obj/structure/barricade/wooden/solid/reinforced,
 /turf/open/floor/plating/indoor/concrete/bricks,
@@ -3098,7 +3120,7 @@ xK
 oI
 Qn
 rE
-oI
+aW
 sE
 pq
 pq
@@ -3258,7 +3280,7 @@ On
 oI
 bQ
 rE
-oI
+aW
 bQ
 rE
 Zt
@@ -4720,7 +4742,7 @@ FV
 iX
 Kn
 XZ
-XZ
+Nx
 iz
 xR
 mR
@@ -4747,7 +4769,7 @@ sG
 hN
 hN
 hN
-hN
+oM
 EM
 kW
 UR
@@ -4921,7 +4943,7 @@ pq
 NT
 ol
 qW
-qW
+kc
 Mo
 qW
 NT
@@ -5419,7 +5441,7 @@ Xu
 aC
 xR
 xR
-kF
+xV
 QY
 kF
 kF

--- a/_maps/map_files/deployment_intruder_outside/deployment_intruder_outside.dmm
+++ b/_maps/map_files/deployment_intruder_outside/deployment_intruder_outside.dmm
@@ -100,7 +100,7 @@
 "kS" = (/turf/open/floor/plating/ground/rockunder,/area/halflife/indoors/intruder/outside)
 "lg" = (/obj/structure/closet/halflife{anchored = 1},/obj/effect/spawner/random/halflife/loot/intruder,/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/miscellaneous_room)
 "lh" = (/obj/machinery/door/unpowered/halflife/metal,/turf/open/floor/plating/indoor/metal/plate,/area/halflife/indoors/intruder/medbay)
-"lj" = (/obj/machinery/light/small/directional/west,/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/storagec)
+"lj" = (/obj/machinery/light/small/directional/west,/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/storagec)
 "lk" = (/obj/structure/railing/halflife/solo{dir = 1},/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/miscellaneous_room)
 "ll" = (/obj/effect/landmark/navigate_destination/halflife/intruder/entrance,/turf/open/floor/plating/ground/sidewalk,/area/halflife/indoors/intruder/outside)
 "lq" = (/obj/machinery/light_switch/directional/north{max_integrity = 999},/turf/open/floor/plating/indoor/tile/kitchen,/area/halflife/indoors/intruder/lab)
@@ -117,7 +117,7 @@
 "mo" = (/turf/cordon,/area/halflife/indoors/intruder/miscellaneous_room)
 "mt" = (/obj/machinery/door/unpowered/halflife/metal{dir = 1},/turf/open/floor/plating/indoor/tile/black,/area/halflife/indoors/intruder/barracks)
 "mv" = (/obj/structure/railing/halflife/full{dir = 1},/turf/open/halflife/water/shallow,/area/halflife/indoors/intruder/outside)
-"mB" = (/obj/machinery/light_switch/directional/south,/turf/open/floor/plating/indoor/tile/black,/area/halflife/indoors/intruder/entrance)
+"mB" = (/obj/machinery/light_switch/directional/south,/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/tile/black,/area/halflife/indoors/intruder/entrance)
 "mC" = (/turf/open/floor/plating/indoor/carpet,/area/halflife/indoors/intruder/library)
 "mF" = (/obj/structure/closet/halflife{anchored = 1},/obj/effect/spawner/random/halflife/loot/intruder,/turf/open/floor/plating/indoor/woodc/fancy,/area/halflife/indoors/intruder/office)
 "mG" = (/obj/machinery/light/small/directional/west,/turf/open/floor/plating/ground/dirt,/area/halflife/indoors/intruder/outside)
@@ -175,7 +175,7 @@
 "rw" = (/turf/open/floor/plating/indoor/tile/kitchen,/area/halflife/indoors/intruder/lab)
 "rE" = (/obj/structure/window/fulltile/halflife/nosmooth/generic{dir = 8},/turf/open/floor/plating/indoor/woodc/mosaic,/area/halflife/indoors/intruder/storageb)
 "rJ" = (/obj/structure/closet/halflife{anchored = 1},/obj/effect/spawner/random/halflife/loot/intruder,/obj/machinery/light/small/directional/west,/turf/open/floor/plating/indoor/woodc/fancy,/area/halflife/indoors/intruder/office)
-"rL" = (/obj/machinery/combine_walllight/directional/west,/turf/open/floor/plating/indoor/metal/smooth,/area/halflife/indoors/intruder/storagesilo)
+"rL" = (/obj/machinery/combine_walllight/directional/west,/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/metal/smooth,/area/halflife/indoors/intruder/storagesilo)
 "rM" = (/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/storagec)
 "rS" = (/obj/effect/landmark/navigate_destination/halflife/intruder/storagea,/turf/open/floor/plating/ground/sidewalk,/area/halflife/indoors/intruder/outside)
 "rY" = (/obj/machinery/light/directional/north,/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/miscellaneous_room)
@@ -196,7 +196,9 @@
 "tm" = (/obj/structure/halflife/barrel/double/red/two,/turf/open/floor/plating/indoor/metal/smooth,/area/halflife/indoors/intruder/storagesilo)
 "ts" = (/obj/structure/halflife/barrel/triple/grey/three,/turf/open/floor/plating/indoor/metal/smooth,/area/halflife/indoors/intruder/storagesilo)
 "tv" = (/obj/structure/halflife/trash/garbage,/turf/open/floor/plating/ground/sidewalk/cobblestone,/area/halflife/indoors/intruder/outside)
+"tB" = (/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/miscellaneous_room)
 "tE" = (/obj/structure/halflife/fence,/turf/open/floor/plating/ground/grass,/area/halflife/indoors/intruder/outside)
+"tL" = (/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/tile/green,/area/halflife/indoors/intruder/lockerroom)
 "tN" = (/obj/machinery/light/small/directional/west,/turf/open/floor/plating/indoor/concrete,/area/halflife/indoors/intruder/storagea)
 "tO" = (/obj/machinery/combine_walllight/directional/west,/turf/open/floor/plating/indoor/metal/combine,/area/halflife/indoors/intruder/storagesilo)
 "tQ" = (/obj/machinery/light/directional/north,/turf/open/floor/plating/ground/rockunder,/area/halflife/indoors/intruder/miscellaneous_room)
@@ -454,8 +456,10 @@
 "Qh" = (/obj/machinery/light_switch/directional/north{max_integrity = 999},/turf/open/floor/plating/indoor/sterilesquares,/area/halflife/indoors/intruder/medbay)
 "Qn" = (/obj/structure/flora/tree/halflife/pine/style_random,/turf/open/floor/plating/ground/grass,/area/halflife/indoors/intruder/outside)
 "QC" = (/turf/open/floor/plating/indoor/woodc/fancy,/area/halflife/indoors/intruder/medbay)
+"QN" = (/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/concrete,/area/halflife/indoors/intruder/guardtower)
 "Rf" = (/obj/machinery/telecomms/server/presets/common/birdstation,/turf/open/floor/plating/ground/sidewalk,/area/halflife/indoors/intruder/outside)
 "Rg" = (/obj/machinery/door/poddoor/shutters/indestructible,/turf/open/floor/plating/indoor/metal/smooth,/area/halflife/indoors/intruder/storagesilo)
+"Rh" = (/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/concrete,/area/halflife/indoors/intruder/storagea)
 "Ri" = (/obj/structure/window/fulltile/halflife/nosmooth/generic{dir = 4},/turf/open/floor/plating/indoor/woodc,/area/halflife/indoors/intruder/storageb)
 "Rq" = (/obj/machinery/light/small/directional/west,/turf/open/floor/plating/indoor/woodc,/area/halflife/indoors/intruder/library)
 "RB" = (/obj/structure/railing/halflife/solo{dir = 8},/turf/open/floor/plating/indoor/concrete/bricks,/area/halflife/indoors/intruder/miscellaneous_room)
@@ -499,6 +503,7 @@
 "VK" = (/turf/closed/wall/halflife/brick,/area/halflife/indoors/intruder/library)
 "VP" = (/obj/machinery/light/directional/east,/turf/open/floor/plating/indoor/concrete,/area/halflife/indoors/intruder/library)
 "Wg" = (/obj/structure/halflife/leaves,/turf/open/floor/plating/ground/dirt,/area/halflife/indoors/intruder/outside)
+"Wh" = (/obj/effect/landmark/intruder_guncase,/turf/open/floor/plating/indoor/woodc/mosaic,/area/halflife/indoors/intruder/storageb)
 "Wp" = (/obj/item/toy/cards/deck{pixel_x = -3; pixel_y = 11},/turf/open/floor/plating/indoor/tile/black,/area/halflife/indoors/intruder/barracks)
 "Wu" = (/obj/structure/closet/crate/bin,/obj/effect/spawner/random/halflife/loot/intruder,/turf/open/floor/plating/ground/grass,/area/halflife/indoors/intruder/outside)
 "WL" = (/obj/structure/lattice/catwalk/hl13,/obj/structure/railing/halflife/full{dir = 8},/turf/open/openspace,/area/halflife/indoors/intruder/guardtower)
@@ -600,7 +605,7 @@ crcrcrcrcrcrgDgDeFKiREAHAHAHAHREAHAHAHAHAHAHAHAHAHAHAHAHREJRJRJRJRJRJRJRJRwlCkwl
 crcrcrcrcrcrCkCkCkCkLcCkCkCkCkxiCkCkCkCkCkCkCkCkCkCkCkCkwlJRbzzDrbxNKnvTJRwlCkwlqNqNqNqNqNqNqNCwCkwlgDgDgDgDQngDgDgDgDEVEVEVgDEVEVEVEVEVEVEVEVEVEVEVkSkSkSkSEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcrCkCkCkCkLcCkCkCkCkxiCkCkCkCkCkpqCkCkCkCkCkCkpbJRbOCLihihihVjJRwlCknmqNJcFWJcJcxyqNwlCkwlgDgDgDgDgDvXgDgDgDEVEVEVEVEVEVEVEVEVEVEVEVEVEVkSkSkSkSkSEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcrCkCkCkCkLcCkCkCkCkxiCkCkCkCkCkCkgvCkCkpqgvCkwlJRtNUkihihihhwJRwlCkqwIZJcJcJcJcFWqNwlCkwlgDXPgDeFgDgDgDgDgDEVEVEVEVEVEVEVEVEVEVEVEVEVEVkSkSEVkSkSEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
-crcrcrcrcrcreFgDgDKiDsDspcpcDsDsCMCkCkCkCkCkCkCkCkCkCkCkwldvihihihihihVjJRwlCkwlqNJcuCJcJcmSqNCwCkwlgDeFeFxBvXgDgDgDEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVkSkSEVkSkSkSEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
+crcrcrcrcrcreFgDgDKiDsDspcpcDsDsCMCkCkCkCkCkCkCkCkCkCkCkwldvihihihihihRhJRwlCkwlqNJcuCJcJcmSqNCwCkwlgDeFeFxBvXgDgDgDEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVkSkSEVkSkSkSEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcreFgDgDgDDsylLALhvpDsCkCkCkCkCkCkCkCkCkCkCkCkwldvihihihihUkVjJRwlCkwlqNqNqNqNJcJcqNwlCkwlgDeFeFeFgDgDgDEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVkSEVEVkSkSEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcreFvXgDQnDsBvjufoBvDstvCkCkCkCkCkCkCkCkCkCkCkwlJRAiihihCLihJVJRCwCkwlqNwTwTqNJcJcqNwlCkwlgDgDxBgDgDgDEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVkSkSEVEVkSkSEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcrgDgDgDgDDsRDjujusbDswrCkCkCkCkpqCkCkCkCkCkCkpbJRtNihUkihihihdIwlCkwlqNJcJcqNJcJcqNCwCkwlgDgDgDgDgDgDEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVkSkSEVkSkSkSEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
@@ -616,12 +621,12 @@ EVEVEVEVEVEVEVEVEVEVEVEVgDgDQngDgDgDwlCkwlgDQngDgDgDgDgDQngDgDgDQngDgDgDgDwlCkwl
 EVEVEVEVEVEVEVEVEVEVEVEVgDgDgDgDvXgDwlCkwlgDeFgDQngDQngDgDgDvXgDgDgDgDgDgDwlCkwlgDgDgDgDgDgDgDwlCkwlgDGHuQuQuQuQuQuQuQuQGHgDeFEVEVkSkSEVEVEVkSkSkSkSkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVgDgDgDgDeFwlCkwlgDeFvXgDgDgDgDeFuquququququqgDeFwlCkwlgDQneFgDQngDgDwlCkwlKiGHjMguguDKguOiguLOGHmGeFeFkSkSkSkSEVEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVgDgDQneFzEwlCkwlgDgDeFgDgDgDeFeFuqddmhNXyGuqsEeFwlCkwlgDgDeFgDgDgDQnwlCkwlgDGHQdXoXoBXXoXoXoXozVgDeFkSkSkSkSkSEVEVkSkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
-EVEVEVEVEVEVEVEVEVEVEVEVEVgDeFeFgDgDwlCkwlgDgDgDvXgDQnuququqyGyGyGUCuqgDgDwlCkwlgDeFvXgDgDgDQnwlCkwlgDGHLOLOLOXoLOLOLOLOGHgDgDEVEVkSkSEVEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
+EVEVEVEVEVEVEVEVEVEVEVEVEVgDeFeFgDgDwlCkwlgDgDgDvXgDQnuququqtByGyGUCuqgDgDwlCkwlgDeFvXgDgDgDQnwlCkwlgDGHLOLOLOXoLOLOLOLOGHgDgDEVEVkSkSEVEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVeFeFvXQngDwlCkwlQngDeFeFeFgDuqxnuqBhaZPkYpuqQngDwlCkwleFeFgDgDQngDgDwlCkwleFGHLOguguXoguguguPPGHgDgDEVEVkSkSEVEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVgDgDgDgDgDwlCkwlgDxBgDgDQngDuqfxuqlgyGyGlguqgDvXwlCkwlgDQngDgDgDxBgDwlCkwlgDGHCOXoBXXoXoBXXoLOGHgDgDgDEVkSkSkSEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVEVeFgDgDvXwlCkwlgDgDzEgDgDvXuqEBuququqPIuquqgDgDwlCkwlzEvXgDQngDeFzEwlCkwlwZGHLOLOLOXoLOLOLOKHGHgDQngDEVEVkSkSEVkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVREeFgDgDgDwlCkwlwlwlwlwlwlwlwlwlwlnTwlwlwlnTwlwlwlCkwlwlwlwlwlwlwlwlwlCkwleFGHTxLOLOXoPPGHGHGHGHgDvXgDEVEVEVkSkSkSkSEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
-EVEVEVEVEVEVEVEVEVEVkSkSkSgHeFgDQngDwlCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkwlJrLwXoXoXoXoLOGHgDgDgDgDgDEVEVEVEVEVEVkSkSEVuququququququququququququqEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
+EVEVEVEVEVEVEVEVEVEVkSkSkSgHeFgDQngDwlCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkCkwlJrLwXoXoXoXotLGHgDgDgDgDgDEVEVEVEVEVEVkSkSEVuququququququququququququqEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVkSkSkSkSkSeFgDzEwlwlwlwlwlwlwlwlwlwlwlwlwlwlwlwlwlCkCkwlwlwlwlwlwlwlwlwlwlwlwlwlwlLwXoXoXoXoXLGHgDQngDgDgDEVEVEVEVEVEVkSiXkSsZsZtQsZsZtQsZyGrYyGyGuquqEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVkSkSkSEVkSeFeFvXgDgDgDgDgDgDeFgDgDgDeFeFvXeFgDbtwlCkCkwlzEgDeFgDgDgDvXgDzEeFgDvXgDGHTxZQoGLOKHGHgDgDvXgDEVEVEVEVEVkSEVkSiXkSsZsZsZsZsZsZsZyGyGyGyGjCuqEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVkSkSkSEVEVEVeFgDgDgDKWzxzxQneFKWvXgDgDgDgDgDeFgDwlCkCkwlgDxBgDgDQngDgDgDvXeFgDgDwZGHGHGHGHHXGHGHgDgDgDEVEVEVEVEVkSkSEVkSiXkSsZsZsZsZsZsZsZyGyGyGyGuquqEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
@@ -693,7 +698,7 @@ EVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZd
 EVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdIyIyIyIyIyHOlxlxlxlxlxlxYQGYGYDPvkZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdrtKRtdtdtdtdluZdZdZdZdZdZdZdZdIyIyIyIyIyvkKKlxlxrqlxlxJeGYNYNMvkZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdWLwzgPgPgPwzTuZdZdZdZdZdZdZdZdIyIyIyIyIyvkvkXAXAvkvkvkvkvkvkvkvkZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEV
-EVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdWLufiEOpyHHHTuZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
+EVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdWLufiEOpQNHHTuZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdWLufyHmHyHCWTuZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVZdZdEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdWLXMyHyHAyjbTuZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdEVZdEVZdEVZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcrZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdWLwzwzhMwzwzTuZdZdZdZdZdZdZdZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
@@ -710,7 +715,7 @@ crcrcrcrcrcrZdZdZdZdIyIyIyIyIyIyZdZdZdZdZdZdZdZdZdZdZdZdZdTyTyTyTyTyTyTyTyZdZdZd
 crcrcrcrcrcrZdZdZdZdIyIyIyIyIyIyZdZdZdZdZdZdZdZdZdZdZdZdZdTyTyTyTyTyTyTyTyZdZdZdrEwDhhgMgMgMqNZdZdZdZdZdZdZdZdZdZdZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcrZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdTyTyTyTyTyTyTyTyZdZdZdrEgMgMgMgMgMqNZdZdZdZdyvyvyvyvyvyvZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 crcrcrcrcrcrZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdqNgMffgMffdKqNZdZdZdZdyvyvyvyvyvyvZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
-crcrcrcrcrcrZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdqNpQORgMItuGqNZdZdZdZdyvyvyvyvyvyvZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
+crcrcrcrcrcrZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdqNpQORWhItuGqNZdZdZdZdyvyvyvyvyvyvZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdqNqNqNqNqNqNqNZdZdZdZdyvyvyvyvyvyvZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdyvyvyvyvyvyvZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV
 EVEVEVEVEVEVEVEVEVEVZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdZdyvyvyvyvyvyvZdZdZdZdEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEVEV

--- a/hl13/code/modules/intruder/counter.dm
+++ b/hl13/code/modules/intruder/counter.dm
@@ -5,6 +5,7 @@ GLOBAL_VAR_INIT(caution_cooldown, 0 SECONDS)
 GLOBAL_VAR_INIT(guards_spawned, 0)
 GLOBAL_VAR_INIT(squad_death, FALSE)
 GLOBAL_LIST_EMPTY(real_objectives)
+GLOBAL_VAR_INIT(osp_mode, FALSE)
 
 /obj/machinery/intruder_time_counter
 	name = "intruder counter"
@@ -46,6 +47,8 @@ GLOBAL_LIST_EMPTY(real_objectives)
 	var/revolver_bullsquid = FALSE
 
 	var/round_length = 0
+
+	var/osp_picked = FALSE
 
 	var/datum/action/cooldown/spell/squad_alert/alert = /datum/action/cooldown/spell/squad_alert //for squad leaders
 	var/datum/action/cooldown/spell/conjure_item/medkit/intruder/tasty = /datum/action/cooldown/spell/conjure_item/medkit/intruder
@@ -199,6 +202,22 @@ GLOBAL_LIST_EMPTY(real_objectives)
 					to_chat(H_player, "<span class='greentext big'>An elite unit has arrived to take down the intruder!</span>")
 			revolver_bullsquid = TRUE
 
+/obj/machinery/intruder_time_counter/proc/attempt_pick_osp()
+	var/list/osp_equipment = list(
+		/obj/item/suppressor,
+		/obj/item/suppressor,
+		/obj/item/gun/ballistic/automatic/pistol/solid_tranq/osp,
+		/obj/item/gun/ballistic/automatic/pistol/usp/solid,
+		/obj/item/gun/ballistic/automatic/m4a1/famas/crab,
+	)
+	for(var/X in osp_equipment)
+		var/obj/machinery/intruder_guncase/guncase = new
+		var/picked_weapon = pick(osp_equipment)
+		guncase.case_contains = picked_weapon
+		var/index = osp_equipment.Find(picked_weapon)
+		if(index)
+			osp_equipment.Cut(index, index + 1)
+
 /obj/machinery/intruder_time_counter/proc/attempt_pick_objectives()
 	if(length(GLOB.real_objectives) == 2)
 		return
@@ -223,6 +242,9 @@ GLOBAL_LIST_EMPTY(real_objectives)
 	bullsquid_readiness += (GLOB.complete_objectives * 3)
 	bullsquid_readiness += GLOB.bonus_guard_preparedness
 
+	if(GLOB.osp_mode && !osp_picked)
+		osp_picked = TRUE
+		attempt_pick_osp()
 	if(!revolver_bullsquid && bullsquid_readiness > 30)
 		attempt_pick_bullsquid() //bullsquid gets picked first mostly because of debugging and not actual gameplay reasons
 	while(new_team_leaders < CEILING(GLOB.guards_spawned / 4, 1))
@@ -267,6 +289,8 @@ GLOBAL_LIST_EMPTY(real_objectives)
 			var/final_score = GLOB.alert_phases
 			to_chat(world, span_infoplain(span_bold("Alerts: [final_score]")))
 			to_chat(world, span_infoplain(span_bold("Codename: Belligerent Bullsquid"))) //codename makes even more sense now since you have to kill the man himself to get his codename
+			if(GLOB.osp_mode)
+				to_chat(world, span_infoplain(span_bold("OSP Run Confirmed")))
 			STOP_PROCESSING(SSprocessing, src)
 
 		if(SSticker.tdm_rebel_deaths == 1 && SSticker.IsRoundInProgress())

--- a/hl13/code/modules/intruder/intruder.dm
+++ b/hl13/code/modules/intruder/intruder.dm
@@ -105,7 +105,7 @@
 		if(hooman.glasses == src)
 			hooman.update_sight()
 	else
-		vision_flags = SEE_MOBS
+		vision_flags = SEE_MOBS|SEE_TURFS|SEE_OBJS
 		var/mob/living/carbon/human/hooman = loc
 		if(hooman.glasses == src)
 			hooman.update_sight()
@@ -123,6 +123,11 @@
 /obj/item/gun/ballistic/automatic/pistol/usp/suppressed/solid
 	desc = "A small and light 9mm pistol which is often used as a metropolice standard carry. Unlike most found in the city, nearly every part of this gun has been expertly crafted and customized. Where'd you get something like this...?"
 	projectile_damage_multiplier = 2.5
+
+/obj/item/gun/ballistic/automatic/pistol/usp/solid
+	desc = "A small and light 9mm pistol which is often used as a metropolice standard carry. Unlike most found in the city, nearly every part of this gun has been expertly crafted and customized. Where'd you get something like this...?"
+	projectile_damage_multiplier = 2.5
+	spawnwithmagazine = FALSE //OSP
 
 /obj/item/storage/belt/civilprotection/polish_resistance/solid
 	desc = "Heavy duty belt for containing metrocop standard gear. Can also carry rations. Can't carry large magazines."
@@ -215,6 +220,10 @@
 	SSwardrobe.provide_type(/obj/item/grenade/syndieminibomb/bouncer, src)
 	update_appearance(UPDATE_ICON)
 
+/obj/item/storage/belt/civilprotection/polish_resistance/solid/belligerent/empty/PopulateContents()
+	SSwardrobe.provide_type(/obj/item/knife/combat, src) //im not a complete asshole
+	update_appearance(UPDATE_ICON)
+
 /obj/item/storage/belt/civilprotection/polish_resistance/solid/phantom/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 16
@@ -257,7 +266,7 @@
 	SSwardrobe.provide_type(/obj/item/gun/ballistic/automatic/pistol/solid_tranq, src)
 
 /obj/item/storage/backpack/halflife/satchel/civilprotection/solid/m4a1/PopulateContents()
-	SSwardrobe.provide_type(/obj/item/gun/ballistic/automatic/m4a1/famas/crab, src)
+	SSwardrobe.provide_type(/obj/item/gun/ballistic/automatic/m4a1/famas/crab/suppressed, src)
 	SSwardrobe.provide_type(/obj/item/gun/ballistic/automatic/pistol/usp/suppressed/solid, src)
 
 /obj/item/reagent_containers/pill/patch/medkit/ration
@@ -522,12 +531,15 @@
 			/obj/item/storage/box/intruder_snake/classic,
 			/obj/item/storage/box/intruder_snake/belligerent,
 			/obj/item/storage/box/intruder_snake/phantom,
+			/obj/item/storage/box/intruder_snake/osp,
 		)
 		for(var/obj/item/option as anything in possible_options)
 			options[initial(option.name)] = option
 	return options
 
 /obj/item/choice_beacon/intruder_snake_loadout/spawn_option(obj/item/storage/box/choice_path, mob/living/user)
+	if(choice_path == /obj/item/storage/box/intruder_snake/osp)
+		GLOB.osp_mode = TRUE
 	var/obj/item/storage/just_a_box = new choice_path(user.loc)
 	just_a_box.emptyStorage() //the box is just a vessel for easy transport and itemization, it serves no purpose afterwards
 	qdel(just_a_box)
@@ -552,3 +564,10 @@
 /obj/item/storage/box/intruder_snake/phantom/PopulateContents()
 	new /obj/item/storage/belt/civilprotection/polish_resistance/solid/phantom(src)
 	new /obj/item/storage/backpack/halflife/satchel/civilprotection/solid/tranq_only(src)
+
+/obj/item/storage/box/intruder_snake/osp
+	name = "Naked Crab - (!!HARDMODE!!, ON-SITE PROCUREMENT)"
+
+/obj/item/storage/box/intruder_snake/osp/PopulateContents()
+	new /obj/item/storage/belt/civilprotection/polish_resistance/solid/belligerent/empty(src) //upside to this loadout is that you get to carry famas mags for the low low cost of everything
+	new /obj/item/storage/backpack/halflife/satchel/civilprotection/solid(src)

--- a/hl13/code/modules/intruder/misc.dm
+++ b/hl13/code/modules/intruder/misc.dm
@@ -1,4 +1,5 @@
 GLOBAL_VAR_INIT(packages_delivered, 0)
+GLOBAL_LIST_EMPTY(intruder_osp)
 
 /obj/machinery/intruder_coffeemaker
 	name = "coffeemaker"
@@ -279,3 +280,50 @@ GLOBAL_VAR_INIT(packages_delivered, 0)
 			new /obj/structure/closet/cardboard/solid(loc)
 			to_chat(user, span_notice("You take out a box of supplies. You can examine it to see what it contains."))
 			boxes_left--
+
+/obj/effect/landmark/intruder_guncase
+	name = "guncase spawn point"
+
+/obj/effect/landmark/intruder_guncase/Initialize(mapload)
+	..()
+	GLOB.intruder_osp += loc
+	return INITIALIZE_HINT_QDEL
+
+/obj/machinery/intruder_guncase
+	name = "gun case"
+	desc = "A weapon's case. You're not sure what the 'S' stands for... Solid? Shoot? Synd-...? Eh, it's probably best not to think too hard about it."
+	icon = 'icons/obj/storage/case.dmi'
+	icon_state = "infiltrator_case"
+	resistance_flags = INDESTRUCTIBLE
+	anchored = TRUE
+	var/case_contains = /obj/item
+
+/obj/machinery/intruder_guncase/examine(mob/user)
+	. = ..()
+	if(!HAS_TRAIT(user, TRAIT_THE_INTRUDER))
+		. += span_notice("You don't really need a new gun right now. Besides, it isn't yours to take.")
+	else
+		if(case_contains == /obj/item/suppressor)
+			. += span_notice("It contains a suppressor... shouldn't it be a 'suppressor case'?")
+		if(case_contains == /obj/item/gun/ballistic/automatic/pistol/solid_tranq/osp)
+			. += span_notice("It contains an empty tranquilizer pistol.")
+		if(case_contains == /obj/item/gun/ballistic/automatic/pistol/usp/solid)
+			. += span_notice("It contains an empty, unsuppressed USP.")
+		if(case_contains == /obj/item/gun/ballistic/automatic/m4a1/famas/crab)
+			. += span_notice("It contains an empty, unsuppressed FAMAS.")
+
+/obj/machinery/intruder_guncase/Initialize(mapload)
+	. = ..()
+	var/turf/picked_loc = pick(GLOB.intruder_osp)
+	GLOB.intruder_osp -= picked_loc //no two weapons in the same location
+	forceMove(picked_loc)
+
+/obj/machinery/intruder_guncase/interact(mob/living/carbon/human/user)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_THE_INTRUDER))
+		if(do_after(user, 1 SECONDS, src))
+			new case_contains(loc)
+			SEND_SOUND(user, sound('hl13/sound/effects/spawnration.ogg'))
+			qdel(src)
+	else
+		to_chat(user, span_notice("You don't really need a new gun right now. Besides, it isn't yours to take."))

--- a/hl13/code/modules/intruder/objectives.dm
+++ b/hl13/code/modules/intruder/objectives.dm
@@ -48,6 +48,8 @@ GLOBAL_LIST_EMPTY(node_terminals)
 		var/title = completion_titles[min(final_score + 1, 6)]
 		to_chat(world, span_infoplain(span_bold("Alerts: [final_score]")))
 		to_chat(world, span_infoplain(span_bold("Codename: [title]")))
+		if(GLOB.osp_mode)
+			to_chat(world, span_infoplain(span_bold("OSP Run Confirmed")))
 		qdel(user)
 
 /obj/machinery/combine_node

--- a/hl13/code/modules/projectiles/guns/ballistic.dm
+++ b/hl13/code/modules/projectiles/guns/ballistic.dm
@@ -155,8 +155,18 @@
 
 /obj/item/gun/ballistic/automatic/m4a1/famas/crab
 	name = "\improper Masterwork FAMAS G2 Rifle"
-	desc = "A french made bullpup rifle from the nineties, made as an upgraded to the FAMAS F1 model. It shares many similarities to the M4A1, and is able to use the same magazines as it does. Boasts an impressive rate of fire, but relatively low accuracy. This one looks in pretty good shape, and somehow more powerful."
+	desc = "A french made bullpup rifle from the nineties, made as an upgraded to the FAMAS F1 model. It shares many similarities to the M4A1, and is able to use the same magazines as it does. Boasts an impressive rate of fire, but relatively low accuracy. This one looks in pretty good shape, and somehow more powerful. It's also capable of taking a suppressor."
 	projectile_damage_multiplier = 1.5
+	can_suppress = TRUE
+	spawnwithmagazine = FALSE //OSP
+
+/obj/item/gun/ballistic/automatic/m4a1/famas/crab/suppressed
+	spawnwithmagazine = TRUE //belligerent
+
+/obj/item/gun/ballistic/automatic/m4a1/famas/crab/suppressed/Initialize(mapload)
+	. = ..()
+	var/obj/item/suppressor/S = new(src)
+	install_suppressor(S)
 
 //sidegrade to the m4a1. Heavier duty: More spread, damage and recoil and less firing speed.
 //about 1.85 seconds TTK, and good AP
@@ -474,6 +484,9 @@
 	inhand_icon_state = "zipgun"
 	lefthand_file = 'hl13/icons/mob/inhands/guns_lefthand.dmi'
 	righthand_file = 'hl13/icons/mob/inhands/guns_righthand.dmi'
+
+/obj/item/gun/ballistic/automatic/pistol/solid_tranq/osp
+	spawnwithmagazine = FALSE //OSP
 
 // about 2.4 seconds TTK assuming you hit your first shot (so no cooldown)
 /obj/item/gun/ballistic/revolver/coltpython


### PR DESCRIPTION
Adds Naked Crab, the fourth loadout which gets rid of LITERALLY EVERYTHING CRAB HAS (except his knife for hold ups). In return, every weapon (unloaded, unsuppressed) is guaranteed to be somewhere on the map. 

Belligerent Crab's FAMAS is suppressed to encourage him to still be a little sneaky

Crab's eyepatch gives him increased levels of visibility than just mobs, although he can still lose it to alerts