### PR TITLE
space now has air

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -16,7 +16,6 @@
 /turf/open/floor/plating/indoor/metal/train,
 /area/shuttle/arrival)
 "s" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/highsecurity/combine,
 /turf/open/floor/plating/indoor/metal/train,
 /area/shuttle/arrival)
@@ -81,7 +80,7 @@ B
 B
 B
 B
-B
+H
 H
 "}
 (2,1,1) = {"
@@ -94,8 +93,8 @@ d
 W
 l
 v
-z
 l
+v
 B
 B
 H
@@ -126,8 +125,8 @@ J
 W
 M
 U
-z
 M
+U
 B
 B
 H
@@ -145,6 +144,6 @@ B
 B
 B
 B
-B
+H
 H
 "}

--- a/_maps/shuttles/cargo_box.dmm
+++ b/_maps/shuttles/cargo_box.dmm
@@ -2,12 +2,34 @@
 "b" = (
 /turf/closed/wall/halflife/metal,
 /area/shuttle/supply)
+"d" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo_train";
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/walkway{
+	dir = 1
+	},
+/area/shuttle/supply)
 "e" = (
-/turf/open/floor/plating/indoor/metal/smooth,
+/obj/machinery/combine_walllight/directional/east,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/shuttle/supply)
 "i" = (
-/obj/machinery/light/small/cyan/directional/north,
-/turf/open/floor/plating/indoor/metal/smooth,
+/obj/structure/railing/halflife/full{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo_train";
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/metal/walkway{
+	dir = 1
+	},
+/area/shuttle/supply)
+"l" = (
+/obj/machinery/combine_walllight/directional/west,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/shuttle/supply)
 "s" = (
 /turf/template_noop,
@@ -19,105 +41,122 @@
 /turf/closed/wall/halflife/metal,
 /area/shuttle/supply)
 "u" = (
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/door/airlock/highsecurity/combine,
-/turf/open/floor/plating/indoor/metal/smooth,
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo_train"
+	},
+/turf/open/floor/plating/indoor/metal/walkway{
+	dir = 1
+	},
+/area/shuttle/supply)
+"y" = (
+/obj/machinery/button/door{
+	id = "cargo_train"
+	},
+/turf/closed/wall/halflife/metal,
+/area/shuttle/supply)
+"B" = (
+/obj/structure/railing/halflife/full,
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo_train"
+	},
+/turf/open/floor/plating/indoor/metal/walkway{
+	dir = 1
+	},
 /area/shuttle/supply)
 "O" = (
-/obj/machinery/light/small/cyan/directional/south,
-/turf/open/floor/plating/indoor/metal/smooth,
+/turf/open/floor/plating/indoor/metal/combine/alt2,
 /area/shuttle/supply)
 
 (1,1,1) = {"
+s
 b
 b
 b
-b
-b
+s
 "}
 (2,1,1) = {"
+y
 b
-e
-e
-e
 b
+b
+y
 "}
 (3,1,1) = {"
-u
+i
+O
 e
-e
-e
-u
+O
+B
 "}
 (4,1,1) = {"
-b
-i
-e
+d
 O
-b
+O
+O
+u
 "}
 (5,1,1) = {"
-b
-e
-e
-e
-b
+i
+O
+O
+O
+B
 "}
 (6,1,1) = {"
-b
-e
-e
-e
-b
+i
+O
+O
+O
+B
 "}
 (7,1,1) = {"
-b
-e
-e
-e
-b
+i
+O
+O
+O
+B
 "}
 (8,1,1) = {"
-b
-e
-e
-e
-b
+i
+O
+O
+O
+B
 "}
 (9,1,1) = {"
-b
-e
-e
-e
-b
+i
+O
+O
+O
+B
 "}
 (10,1,1) = {"
-b
 i
-e
 O
-b
+O
+O
+B
 "}
 (11,1,1) = {"
-u
-e
-e
-e
+d
+O
+O
+O
 u
 "}
 (12,1,1) = {"
-b
-e
-e
-e
-b
+i
+O
+l
+O
+B
 "}
 (13,1,1) = {"
+y
 b
 b
-e
 b
-b
+y
 "}
 (14,1,1) = {"
 s

--- a/_maps/shuttles/emergency_backup.dmm
+++ b/_maps/shuttles/emergency_backup.dmm
@@ -99,7 +99,6 @@
 /turf/open/floor/plating/indoor/grooved,
 /area/shuttle/escape/backup)
 "t" = (
-/obj/structure/fans/tiny/invisible,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -131,7 +130,6 @@
 /obj/machinery/door/unpowered/halflife/seethrough/metal{
 	dir = 8
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/grooved,
 /area/shuttle/escape/backup)
 "A" = (
@@ -169,7 +167,6 @@
 /turf/closed/wall/halflife/metal/strong/train,
 /area/shuttle/escape/backup)
 "I" = (
-/obj/structure/fans/tiny/invisible,
 /obj/structure/railing{
 	dir = 8
 	},

--- a/_maps/shuttles/emergency_loyalist.dmm
+++ b/_maps/shuttles/emergency_loyalist.dmm
@@ -158,7 +158,6 @@
 /turf/open/indestructible/plating,
 /area/shuttle/escape)
 "mT" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/highsecurity/combine,
 /turf/open/indestructible/plating,
 /area/shuttle/escape)
@@ -375,7 +374,6 @@
 /turf/open/floor/plating/indoor/metal/pipe,
 /area/shuttle/escape)
 "Rn" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/highsecurity/combine,
 /turf/open/floor/plating/indoor/grooved,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_poland.dmm
+++ b/_maps/shuttles/emergency_poland.dmm
@@ -49,7 +49,7 @@
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "eH" = (
-/obj/machinery/door/airlock/highsecurity/combine,
+/obj/machinery/door/unpowered/halflife/metal/red,
 /turf/open/floor/plating/indoor/metal/grate/border/warning{
 	dir = 1
 	},
@@ -108,7 +108,9 @@
 	},
 /area/shuttle/escape)
 "gt" = (
-/obj/machinery/door/airlock/highsecurity/combine,
+/obj/machinery/door/unpowered/halflife/metal/red{
+	dir = 8
+	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "je" = (
@@ -150,13 +152,11 @@
 	preferred_direction = 2;
 	port_direction = 2
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/walkway{
 	dir = 1
 	},
 /area/shuttle/escape)
 "mk" = (
-/obj/structure/fans/tiny/invisible,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/shuttle/escape)
@@ -175,7 +175,7 @@
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/shuttle/escape)
 "oH" = (
-/turf/closed/wall/halflife/metal/strong,
+/turf/closed/wall/halflife/metal/weak/old,
 /area/shuttle/escape)
 "pQ" = (
 /obj/structure/chair/halflife/metal/red,
@@ -188,7 +188,9 @@
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/shuttle/escape)
 "qq" = (
-/obj/machinery/door/airlock/highsecurity/combine,
+/obj/machinery/door/unpowered/halflife/metal/red{
+	dir = 4
+	},
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/shuttle/escape)
 "qv" = (
@@ -206,7 +208,6 @@
 	},
 /area/shuttle/escape)
 "rj" = (
-/obj/structure/fans/tiny/invisible,
 /obj/structure/halflife/large_pipe/pump,
 /turf/open/floor/plating/indoor/metal/grate/border/warning,
 /area/shuttle/escape)
@@ -282,7 +283,7 @@
 	},
 /area/shuttle/escape)
 "zi" = (
-/obj/machinery/door/airlock/highsecurity/combine,
+/obj/machinery/door/unpowered/halflife/metal/red,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/escape)
 "AT" = (
@@ -301,7 +302,7 @@
 	pixel_y = -32;
 	dir = 1
 	},
-/turf/closed/wall/halflife/metal/strong,
+/turf/closed/wall/halflife/metal/weak/old,
 /area/shuttle/escape)
 "BZ" = (
 /obj/structure/halflife/large_pipe/pump,
@@ -320,7 +321,6 @@
 "Ck" = (
 /obj/structure/barricade/wooden/crude,
 /obj/structure/girder,
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/grate/border/warning{
 	dir = 1
 	},
@@ -361,7 +361,6 @@
 	},
 /area/shuttle/escape)
 "Hn" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/indoor/metal/walkway/end,
 /area/shuttle/escape)
@@ -384,8 +383,9 @@
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/escape)
 "Ig" = (
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/door/airlock/highsecurity/combine,
+/obj/machinery/door/unpowered/halflife/metal/red{
+	dir = 4
+	},
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "Im" = (
@@ -393,7 +393,7 @@
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/shuttle/escape)
 "Io" = (
-/obj/structure/window/fulltile,
+/obj/structure/window/fulltile/halflife/nosmooth/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "poland_shuttle_windows"
 	},
@@ -437,7 +437,6 @@
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/shuttle/escape)
 "Kv" = (
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/walkway/corner,
 /area/shuttle/escape)
 "Lv" = (
@@ -472,18 +471,9 @@
 	},
 /area/shuttle/escape)
 "Ny" = (
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/walkway/corner{
 	dir = 1
 	},
-/area/shuttle/escape)
-"NT" = (
-/obj/structure/window/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "poland_shuttle_windows"
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "Or" = (
 /obj/structure/table/halflife/no_smooth/large/crafting/weaponbench,
@@ -521,7 +511,6 @@
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/escape)
 "Qh" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/light/blacklight/directional/south{
 	bulb_colour = "#ff0000";
 	nightshift_light_color = "#ff0000"
@@ -555,7 +544,6 @@
 	id = "poland_shuttle_windows"
 	},
 /obj/structure/barricade/sandbags,
-/obj/structure/fans/tiny/invisible,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
@@ -574,17 +562,18 @@
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/escape)
 "WL" = (
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/walkway{
 	dir = 1
 	},
 /area/shuttle/escape)
 "WY" = (
-/obj/machinery/door/airlock/highsecurity/combine,
+/obj/machinery/door/unpowered/halflife/metal{
+	dir = 4
+	},
 /turf/open/floor/plating/indoor/sterilesquares,
 /area/shuttle/escape)
 "Zi" = (
-/obj/structure/window/fulltile,
+/obj/structure/window/fulltile/halflife/nosmooth/reinforced,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "Zq" = (
@@ -601,18 +590,18 @@
 Kv
 Qh
 oH
-NT
+Io
 oH
 oH
 TN
 oH
 Ig
 oH
-NT
+Io
 oH
 Ig
 oH
-NT
+Io
 oH
 oH
 oH
@@ -624,7 +613,7 @@ TN
 oH
 oH
 oH
-NT
+Io
 oH
 Bv
 jC
@@ -793,14 +782,14 @@ mk
 Ny
 Hn
 oH
-NT
+Io
 oH
 oH
 TN
 oH
 oH
 oH
-NT
+Io
 oH
 oH
 oH
@@ -808,11 +797,11 @@ TN
 oH
 oH
 oH
-NT
+Io
 oH
 oH
 oH
-NT
+Io
 oH
 oH
 oH

--- a/_maps/shuttles/emergency_priority.dmm
+++ b/_maps/shuttles/emergency_priority.dmm
@@ -17,7 +17,6 @@
 /turf/open/floor/plating/indoor/checkered,
 /area/shuttle/escape)
 "cM" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/highsecurity/combine,
 /turf/open/floor/plating/indoor/checkered,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_razortrain.dmm
+++ b/_maps/shuttles/emergency_razortrain.dmm
@@ -32,16 +32,6 @@
 	},
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/escape)
-"ey" = (
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/light/small/directional/west,
-/obj/structure/railing/halflife/sewer{
-	dir = 4
-	},
-/turf/open/floor/plating/indoor/metal/grate/border{
-	dir = 1
-	},
-/area/shuttle/escape)
 "fK" = (
 /obj/structure/chair/comfy/halflife/captain{
 	dir = 8
@@ -50,7 +40,6 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/escape)
 "gi" = (
-/obj/structure/fans/tiny/invisible,
 /obj/structure/railing/halflife/sewer{
 	dir = 4
 	},
@@ -88,14 +77,12 @@
 /turf/closed/wall/halflife/metal/strong,
 /area/shuttle/escape)
 "mb" = (
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/grate/border/warning{
 	dir = 1
 	},
 /area/shuttle/escape)
 "mF" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/fans/tiny/invisible,
 /obj/structure/railing/halflife/sewer{
 	dir = 4
 	},
@@ -128,7 +115,6 @@
 /area/shuttle/escape)
 "sG" = (
 /obj/structure/window/fulltile,
-/obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/plating,
 /area/shuttle/escape)
 "tA" = (
@@ -143,7 +129,6 @@
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/escape)
 "us" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/light/small/directional/east,
 /obj/structure/railing/halflife/sewer{
 	dir = 8
@@ -257,18 +242,7 @@
 	},
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/escape)
-"TC" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/fans/tiny/invisible,
-/obj/structure/railing/halflife/sewer{
-	dir = 8
-	},
-/turf/open/floor/plating/indoor/metal/grate/border{
-	dir = 1
-	},
-/area/shuttle/escape)
 "Ue" = (
-/obj/structure/fans/tiny/invisible,
 /obj/structure/railing/halflife/sewer{
 	dir = 8
 	},
@@ -302,7 +276,7 @@ mb
 mb
 mb
 Ue
-TC
+us
 Ue
 Ue
 Ue
@@ -310,11 +284,11 @@ mb
 mb
 mb
 Ue
-TC
+us
 Ue
 Ue
 Ue
-TC
+us
 Ue
 Ue
 Ue
@@ -534,11 +508,11 @@ mF
 gi
 gi
 gi
-ey
+mF
 gi
 gi
 gi
-ey
+mF
 gi
 lJ
 lJ

--- a/_maps/shuttles/emergency_scrapped.dmm
+++ b/_maps/shuttles/emergency_scrapped.dmm
@@ -45,10 +45,6 @@
 "hI" = (
 /turf/template_noop,
 /area/template_noop)
-"iq" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating/indoor/metal/plate,
-/area/shuttle/escape)
 "jE" = (
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
@@ -117,7 +113,6 @@
 /turf/closed/wall/halflife/metal/strong,
 /area/shuttle/escape)
 "rx" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/highsecurity/combine,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
@@ -266,12 +261,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating/indoor/metal/plate,
-/area/shuttle/escape)
-"PX" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating/indoor/metal/pipe{
-	dir = 1
-	},
 /area/shuttle/escape)
 "RZ" = (
 /obj/structure/halflife/trash/glass/cans,
@@ -486,9 +475,9 @@ bA
 bA
 pZ
 dm
-PX
-PX
-PX
+bA
+bA
+bA
 bA
 qQ
 qQ
@@ -520,8 +509,8 @@ qQ
 qQ
 qQ
 hI
-iq
-iq
+jE
+jE
 qQ
 qQ
 hI

--- a/_maps/shuttles/ferry_fancy.dmm
+++ b/_maps/shuttles/ferry_fancy.dmm
@@ -58,7 +58,6 @@
 /area/shuttle/transport)
 "H" = (
 /obj/machinery/door/airlock/highsecurity/combine,
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal/combine,
 /area/shuttle/transport)
 "L" = (

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -32,7 +32,6 @@
 	lockid = "rebel_trainstation";
 	keylock = 1
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/syndicate/hallway)
 "ax" = (
@@ -46,7 +45,6 @@
 /obj/structure/railing/halflife/solo{
 	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/syndicate/hallway)
 "aB" = (
@@ -62,7 +60,6 @@
 /obj/structure/railing/halflife/solo{
 	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/syndicate/hallway)
 "bx" = (
@@ -70,18 +67,9 @@
 /obj/structure/bed/halflife/mattress/stained,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/syndicate/hallway)
-"nN" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating/indoor/woodc/wide,
-/area/shuttle/syndicate/hallway)
 "pQ" = (
 /obj/machinery/computer/shuttle/syndicate,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating/indoor/woodc/wide,
-/area/shuttle/syndicate/hallway)
-"qO" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/syndicate/hallway)
 "st" = (
@@ -98,7 +86,6 @@
 /obj/structure/railing/halflife/solo{
 	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/syndicate/hallway)
 "vH" = (
@@ -148,7 +135,6 @@
 /area/shuttle/syndicate/hallway)
 "Rx" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/woodc/wide,
 /area/shuttle/syndicate/hallway)
 "UN" = (
@@ -169,8 +155,8 @@ aa
 aa
 uS
 Rx
-nN
-nN
+st
+st
 bn
 aa
 aa
@@ -288,9 +274,9 @@ aa
 aa
 aa
 ax
-qO
-nN
-nN
+Fd
+st
+st
 bn
 aa
 aa

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -13,7 +13,6 @@
 /area/shuttle/labor)
 "d" = (
 /obj/machinery/door/airlock/highsecurity/combine,
-/obj/structure/fans/tiny/invisible,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/shuttle/labor)
@@ -28,7 +27,6 @@
 /area/shuttle/labor)
 "g" = (
 /obj/structure/window/fulltile,
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal,
 /area/shuttle/labor)
 "h" = (
@@ -40,11 +38,9 @@
 	preferred_direction = 2
 	},
 /obj/structure/window/fulltile,
-/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/indoor/metal,
 /area/shuttle/labor)
 "i" = (
-/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/highsecurity/combine,
 /turf/open/floor/plating/indoor/metal/smooth,
 /area/shuttle/labor)

--- a/code/game/area/areas/misc.dm
+++ b/code/game/area/areas/misc.dm
@@ -2,6 +2,7 @@
 
 /area/space
 	icon_state = "space"
+	first_time_text = "You Shouldn't Be Here (Space (Please Adminhelp))" //hl13 edit
 	requires_power = TRUE
 	always_unpowered = TRUE
 	static_lighting = FALSE

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(starlight)
 	underfloor_accessibility = UNDERFLOOR_INTERACTABLE
 	rust_resistance = RUST_RESISTANCE_ABSOLUTE
 
-	temperature = TCMB
+	//temperature = TCMB (hl13 edit)
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 700000
 	var/starlight_source_count = 0
@@ -59,7 +59,8 @@ GLOBAL_LIST_EMPTY(starlight)
 	var/destination_x
 	var/destination_y
 
-	var/static/datum/gas_mixture/immutable/space/space_gas = new
+	// var/static/datum/gas_mixture/immutable/space/space_gas = new (hl13 edit, uncomment space_EXPENSIVE.dm's contents too if youre gonna reverse this (which you really shouldnt))
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS //hl13 edit
 	// We do NOT want atmos adjacent turfs
 	init_air = FALSE
 	run_later = TRUE
@@ -74,7 +75,7 @@ GLOBAL_LIST_EMPTY(starlight)
 	bullet_bounce_sound = null
 	vis_flags = VIS_INHERIT_ID //when this be added to vis_contents of something it be associated with something on clicking, important for visualisation of turf in openspace and interraction with openspace that show you turf.
 
-	force_no_gravity = TRUE
+	force_no_gravity = FALSE //hl13 edit
 
 /turf/open/space/basic/New() //Do not convert to Initialize
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/turfs/open/space/space_EXPENSIVE.dm
+++ b/code/game/turfs/open/space/space_EXPENSIVE.dm
@@ -10,6 +10,8 @@
  * If you are facing some odd bug with specifically space, check if it's something that was
  * intentionally ommitted from this implementation.
  */
+
+/* hl13 edit!!!!!! stop freezing our trains out you space nerds!!!
 /turf/open/space/Initialize(mapload)
 	SHOULD_CALL_PARENT(FALSE)
 	air = space_gas
@@ -43,3 +45,4 @@
 				T.multiz_turf_new(src, UP)
 
 	return INITIALIZE_HINT_NORMAL
+*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes space's funky atmos so that trains in transit arent instantly magically spaced
also removes all the magic tiny fans from the trains
ALLERGY WARNING: also remaps the cargo shuttle to match the open-top combine trains from the game
<img width="648" height="265" alt="image" src="https://github.com/user-attachments/assets/7ec0ed85-e9cc-462b-b85c-2268d907a098" />
this will probably make the xen loan event easier to cheese but also MORE TERRIFYING for the combine because instead of it being like one at a time five zombies will instead immediately rush them which is cooler

## Why It's Good For The Game

we are NOT in space and i am getting tired of having to put invisible tiny fans on every train
