### PR TITLE
Surplus Train Fix

### DIFF
--- a/_maps/shuttles/emergency_surplus.dmm
+++ b/_maps/shuttles/emergency_surplus.dmm
@@ -101,7 +101,12 @@
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "le" = (
-/obj/docking_port/mobile/emergency,
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	name = "Transfer Train";
+	preferred_direction = 2;
+	port_direction = 2
+	},
 /turf/closed/wall/halflife/metal/weak/old,
 /area/shuttle/escape)
 "lK" = (
@@ -248,10 +253,10 @@
 /turf/open/floor/plating/indoor/metal,
 /area/shuttle/escape)
 "Bn" = (
-/obj/structure/table/halflife/metal/small,
 /obj/item/food/badrecipe/moldy,
 /obj/item/food/badrecipe/moldy,
 /obj/item/food/badrecipe/moldy,
+/obj/structure/rack,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
 "Cd" = (


### PR DESCRIPTION

## About The Pull Request

The surplus millitary train will no longe 180-degree crash into the city when it arrives. Also fixes this table

## Why It's Good For The Game

Bugfix good

