### PR TITLE
Lambda Emag Train

### DIFF
--- a/_maps/shuttles/emergency_lambda.dmm
+++ b/_maps/shuttles/emergency_lambda.dmm
@@ -1,0 +1,863 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ae" = (
+/obj/structure/table/halflife/no_smooth/wood/stand,
+/obj/item/book/manual/fish_catalog,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"bX" = (
+/turf/closed/wall/halflife/metal/strong/train,
+/area/shuttle/escape)
+"cd" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"cq" = (
+/obj/structure/table/halflife/no_smooth/large/wood/desk/alt,
+/obj/item/modular_computer/laptop,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"cM" = (
+/obj/machinery/door/airlock/highsecurity/combine,
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"eN" = (
+/obj/structure/railing/halflife/solo{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"eO" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/east{
+	name = "armory control";
+	id = "lambda_armory"
+	},
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"fd" = (
+/obj/structure/chair/comfy/halflife/diner{
+	dir = 1
+	},
+/obj/structure/halflife/rug/red,
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"fV" = (
+/obj/structure/aquarium/prefilled,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"gL" = (
+/obj/structure/table/halflife/metal/small,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/food/xen/xenbranch,
+/obj/item/food/xen/xenbranch,
+/obj/item/reagent_containers/pill/patch/grubnugget,
+/obj/item/reagent_containers/pill/patch/grubnugget,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"hG" = (
+/obj/item/chair/halflife/metal/folding,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"im" = (
+/obj/structure/chair/comfy/halflife/diner,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"iH" = (
+/obj/structure/guncase,
+/obj/item/ammo_box/magazine/usp9mm,
+/obj/item/ammo_box/magazine/usp9mm,
+/obj/item/gun/ballistic/automatic/pistol/usp,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"iY" = (
+/obj/item/clipboard,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"jB" = (
+/obj/structure/halflife/rug/red,
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"kv" = (
+/obj/structure/marker_beacon/bronze,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"lH" = (
+/obj/structure/chair/comfy/halflife/diner,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"mN" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/vest/blueshirt,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"mO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"ns" = (
+/obj/structure/table/halflife/no_smooth/large/metal{
+	dir = 4
+	},
+/obj/structure/showcase/machinery/microwave,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"nM" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"oM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"qb" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/alien/weeds,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"qc" = (
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"qA" = (
+/obj/machinery/door/poddoor/shutters/radiation{
+	desc = "Lead-lined shutters with a radiation hazard symbol.";
+	id = "lambda_armory";
+	name = "armory shutters"
+	},
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"qK" = (
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"qX" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"rf" = (
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"sK" = (
+/obj/structure/table/halflife/metal/small,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/item/stack/ore/bluespace_crystal/refined,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"tE" = (
+/obj/structure/closet/cabinet,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/item/clothing/suit/toggle/labcoat/halflife,
+/obj/item/clothing/mask/gas/hl2/modern,
+/obj/item/clothing/mask/gas/hl2/modern,
+/obj/item/clothing/suit/toggle/labcoat/halflife,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"uy" = (
+/obj/structure/closet/secure_closet/freezer/halflife,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/cup/soda_cans/breenwater,
+/obj/item/reagent_containers/cup/soda_cans/breenwater,
+/obj/item/reagent_containers/cup/soda_cans/breenwater,
+/obj/item/food/pizzaslice/meat{
+	name = "cold pizza slice";
+	desc = "A slice of pizza gone cold. Perhaps you could microwave it up just fine.."
+	},
+/obj/item/food/pizzaslice/meat{
+	name = "cold pizza slice";
+	desc = "A slice of pizza gone cold. Perhaps you could microwave it up just fine.."
+	},
+/obj/item/food/pizzaslice/meat{
+	name = "cold pizza slice";
+	desc = "A slice of pizza gone cold. Perhaps you could microwave it up just fine.."
+	},
+/obj/item/food/pizzaslice/meat{
+	name = "cold pizza slice";
+	desc = "A slice of pizza gone cold. Perhaps you could microwave it up just fine.."
+	},
+/obj/item/food/pizzaslice/meat{
+	name = "cold pizza slice";
+	desc = "A slice of pizza gone cold. Perhaps you could microwave it up just fine.."
+	},
+/obj/item/food/pizzaslice/meat{
+	name = "cold pizza slice";
+	desc = "A slice of pizza gone cold. Perhaps you could microwave it up just fine.."
+	},
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"uz" = (
+/obj/structure/guncase,
+/obj/item/ammo_box/magazine/mp7,
+/obj/item/gun/ballistic/automatic/mp7,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"uL" = (
+/obj/structure/table/halflife/no_smooth/large/wood/desk,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"vt" = (
+/obj/structure/filingcabinet/hl2,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"vF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"wL" = (
+/obj/item/reagent_containers/hypospray/medipen/healthpen,
+/obj/item/reagent_containers/hypospray/medipen/healthpen,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"xl" = (
+/obj/structure/halflife/storage/large/shelf/wood,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/item/storage/backpack/halflife/satchel,
+/obj/item/storage/halflife/suitcase,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"xt" = (
+/obj/machinery/shower/directional/west,
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"xz" = (
+/obj/structure/halflife/storage/large/shelf{
+	dir = 4
+	},
+/obj/item/clothing/suit/toggle/labcoat/halflife,
+/obj/item/clothing/suit/toggle/labcoat/halflife,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"xD" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"zl" = (
+/obj/structure/closet/crate/freezer/halflife{
+	name = "drink cooler"
+	},
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixsoda,
+/obj/item/reagent_containers/cup/glass/ice,
+/obj/item/reagent_containers/cup/glass/ice,
+/obj/item/reagent_containers/cup/glass/ice,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"AL" = (
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"AQ" = (
+/obj/machinery/vending/combine_wallmed/directional/north,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Bi" = (
+/obj/structure/closet/halflife,
+/obj/item/clothing/suit/utility/radiation/cleanup/scientist,
+/obj/item/watertank/cleanup,
+/obj/item/clothing/gloves/halflife/cleanup,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"CP" = (
+/obj/machinery/door/airlock/highsecurity/combine,
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"DO" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"EI" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"EU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Fp" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"FU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"GL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Hd" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"HD" = (
+/obj/machinery/stasis/survival_pod,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Iv" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/mob/living/simple_animal/halflife/harry{
+	name = "Lambda's Interim Mascot";
+	desc = "A supposedly debeaked poison headcrab."
+	},
+/obj/structure/alien/weeds,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"IR" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/alien/weeds,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"JC" = (
+/obj/structure/marker_beacon/bronze,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"JQ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Kh" = (
+/obj/structure/chair/comfy/halflife/diner,
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"Ki" = (
+/obj/machinery/shower/directional/east,
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"Kw" = (
+/obj/structure/chair/comfy/halflife/diner{
+	dir = 1
+	},
+/obj/structure/halflife/rug/red,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"Lf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"LH" = (
+/obj/structure/marker_beacon/bronze,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"LO" = (
+/obj/item/surgery_tray/full/deployed,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"LQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"LW" = (
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Mc" = (
+/obj/structure/railing/halflife/solo{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"ME" = (
+/obj/structure/sign/poster/halflife/rebel/vault,
+/turf/closed/wall/halflife/metal/strong/train,
+/area/shuttle/escape)
+"MO" = (
+/obj/item/storage/box/coffeepack/robusta,
+/obj/item/storage/box/coffeepack/robusta,
+/obj/item/storage/box/coffeepack/robusta,
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"MR" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"Np" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/folder/white,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Nt" = (
+/obj/machinery/door/unpowered/halflife/wood,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Ow" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/chair/office/halflife/red,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"OE" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/rebel/light,
+/obj/item/clothing/suit/armor/rebel/light,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"QK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"QW" = (
+/obj/structure/chair/comfy/halflife/diner{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"Sr" = (
+/obj/structure/railing/halflife/solo{
+	dir = 4
+	},
+/obj/structure/chair/office/halflife/blue,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Tp" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/alien/weeds,
+/obj/structure/flora/xen/mound,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"UC" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"Ve" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/alien/weeds,
+/obj/structure/flora/xen/leafy,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Vh" = (
+/obj/structure/chair/comfy/halflife/diner{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"VC" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/alien/weeds,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Wh" = (
+/turf/template_noop,
+/area/template_noop)
+"Wl" = (
+/obj/machinery/coffeemaker/impressa,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+"WR" = (
+/obj/structure/table/optable,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Xb" = (
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	name = "Lambda Research Train";
+	preferred_direction = 2;
+	port_direction = 2
+	},
+/turf/closed/wall/halflife/metal/strong/train,
+/area/shuttle/escape)
+"Xf" = (
+/obj/machinery/suit_storage_unit/open{
+	name = "HEV suit storage unit"
+	},
+/obj/item/clothing/suit/hooded/hev,
+/obj/item/crowbar/large,
+/obj/item/clothing/glasses/regular,
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"Xv" = (
+/obj/structure/sign/poster/halflife/rebel/two,
+/turf/closed/wall/halflife/metal/strong/train,
+/area/shuttle/escape)
+"Yx" = (
+/obj/structure/chair/comfy/halflife/diner,
+/obj/structure/sign/clock/directional/north,
+/turf/open/floor/plating/indoor/tiled9,
+/area/shuttle/escape)
+"Zb" = (
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"Zk" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/indoor/sterilesquares,
+/area/shuttle/escape)
+"Zr" = (
+/obj/effect/spawner/random/trash/graffiti/halflife/lambdaspray,
+/turf/open/floor/plating/indoor/carpet/blue,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+Wh
+bX
+bX
+bX
+bX
+bX
+bX
+cM
+bX
+bX
+bX
+bX
+bX
+cM
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+Wh
+"}
+(2,1,1) = {"
+bX
+Xv
+Wl
+ns
+MO
+bX
+im
+jB
+oM
+LW
+LW
+JQ
+AL
+AL
+Kw
+bX
+Ki
+UC
+bX
+HD
+LO
+WR
+xD
+Bi
+EI
+Lf
+Lf
+GL
+bX
+Xv
+mN
+uz
+bX
+bX
+bX
+"}
+(3,1,1) = {"
+bX
+zl
+qc
+qc
+qc
+ME
+Kh
+AL
+vt
+Mc
+LW
+Mc
+tE
+AL
+Vh
+bX
+rf
+rf
+CP
+LW
+LW
+LW
+LW
+LW
+Ow
+Tp
+qb
+EU
+qA
+mO
+qK
+qK
+LH
+bX
+bX
+"}
+(4,1,1) = {"
+Xb
+nM
+hG
+Zr
+qc
+Nt
+AL
+AL
+uL
+LW
+LW
+LW
+xl
+AL
+AL
+CP
+rf
+MR
+bX
+AQ
+LW
+LW
+LW
+LW
+Zk
+VC
+Iv
+EU
+qA
+Zb
+Zb
+kv
+Xf
+bX
+bX
+"}
+(5,1,1) = {"
+bX
+uy
+qc
+qc
+ae
+bX
+Yx
+jB
+Np
+Sr
+LW
+eN
+Hd
+AL
+fd
+bX
+rf
+rf
+CP
+LW
+LW
+gL
+LW
+cq
+Ow
+IR
+Ve
+EU
+qA
+FU
+qK
+qK
+JC
+bX
+bX
+"}
+(6,1,1) = {"
+bX
+Xv
+Fp
+eO
+fV
+bX
+lH
+AL
+vF
+LW
+LW
+LQ
+AL
+AL
+QW
+bX
+xt
+qX
+bX
+wL
+xz
+sK
+LW
+iY
+cd
+QK
+QK
+DO
+bX
+Xv
+OE
+iH
+bX
+bX
+bX
+"}
+(7,1,1) = {"
+Wh
+bX
+bX
+bX
+bX
+bX
+bX
+cM
+bX
+bX
+bX
+bX
+bX
+cM
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+bX
+Wh
+"}

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -110,4 +110,12 @@
 	emag_only = TRUE
 	occupancy_limit = "25"
 
+/datum/map_template/shuttle/emergency/lambda
+	suffix = "lambda"
+	name = "Lambda Resistance Research Train"
+	credit_cost = CARGO_CRATE_VALUE * 30
+	description = "Hearing of the PLF's offer, we at Lambda would like to show one of our own vessels as an option instead. What you lose in loud value and armaments you gain back in the comfort and utility of our research vessel, complete with a single repaired HEV suit for your using pleasure. This train made an easy arrival with our experiments into Xen Crystals, but it is still a one-way trip; be prepared, as this train will come back without you."
+	emag_only = TRUE
+	occupancy_limit = "15"
+
 #undef EMAG_LOCKED_SHUTTLE_COST


### PR DESCRIPTION
## About The Pull Request

A train from Lambda appears as a counteroffer to the PLF Armored Train. This train is a retrofit of a standard train equipped with research facilities and a small armory and breakroom, for making a convenient escape and primarily an infiltration of any combine train recovery wing- this train is primarily in operation via Lambda's research into teleportation and Xen crystals, being just camouflaged enough to go under the radar before it can be extracted back to a safe holding area. Buying this means a one-way trip, but hey, its comfy and Lambda will let you have one of their HEV suits. 
Note: Armory controls are in the breakroom and start closed for safety reasons. Contains Xen Crystals, 10, which can be used for teleportation. Note Note: You may teleport off the train and get owned if you try having a snowball fight with these crystals.
<img width="227" height="1113" alt="image" src="https://github.com/user-attachments/assets/917732a4-408d-4782-9978-5fcf1e83a31c" />

## Why It's Good For The Game

More train variety, more reason to actually emag the comms console.

## Changelog


:cl:
add: lambda emag shuttle
/:cl:

