### PR TITLE
Adds New Cargo Emag Items

### DIFF
--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -4,8 +4,53 @@
  * This allows us to have a few crates meant for deliberate purchase through cargo, and for cargo to have a few items
  * they explicitly control. It also holds all of the black market material and contraband material, including items
  * meant for purchase only through emagging the console.
+ * HL13: Primarily contaband buys, lower sociostability when purchased.
  */
 
 /datum/supply_pack/imports
 	group = "Imports"
-	crate_name = "emergency crate"
+	crate_name = "smuggled crate"
+
+/datum/supply_pack/imports/pierogi
+	name = "Pierogi Delivery"
+	desc = "Baked with love by the Polish Liberation Front, unlike those expensive and tasteless Pierogi Rations. Contains x3 Meat Pierogi, x3 Cheese Pierogi."
+	hidden = TRUE
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(
+		/obj/item/food/cheese_pierogi = 3,
+		/obj/item/food/meat_pierogi = 3,
+	)
+	socio_cost = -10
+
+/datum/supply_pack/imports/rebelarmor
+	name = "Light Resistance Armor"
+	desc = "Armor defiantly stolen from the many Civil Protection units and factories both Lambda and the Polish Liberation Front has raided, modified to protect and provide more value then standard CPO vests. Consider this an alternative option should you not be able to source armor on-site, agent. Contains x3 Rebel Light Armor, and as a regional bonus x3 Polish Armbands."
+	hidden = TRUE
+	cost = CARGO_CRATE_VALUE * 4
+	contains = list(
+		/obj/item/clothing/accessory/armband/plf = 3,
+		/obj/item/clothing/suit/armor/rebel/light = 3,
+	)
+	socio_cost = -15
+
+/datum/supply_pack/imports/uprising
+	name = "Bulk Civil Uprising Starter Kit"
+	desc = "Start your own revolution today for cheap! No need to buy guns and armor, simply hand these out! *Not responsible for loss of life- promise of free state not guranteed. Contains x4 Molotov, x2 Lighter, x9 Bricks, x3 Gas Masks, x6 Refugee Suits, x2 Kevlar Vests, x2 Brown Overcoats, x6 Broken Bottles, x4 Healthpens, x2 Makeshift Pistol, x2 Makeshift Pistol Magazine, x1 Polish Liberation Front Beret, x1 Megaphone."
+	hidden = TRUE
+	cost = CARGO_CRATE_VALUE * 4
+	contains = list(
+		/obj/item/grenade/halflife/molotov = 4,
+		/obj/item/lighter = 2,
+		/obj/item/stack/sheet/halflife/brick = 9,
+		/obj/item/clothing/mask/gas/hl2/military = 3,
+		/obj/item/clothing/under/citizen/refugee = 6,
+		/obj/item/clothing/suit/armor/halflife/kevlar = 2,
+		/obj/item/clothing/suit/armor/browncoat = 2,
+		/obj/item/broken_bottle = 6,
+		/obj/item/reagent_containers/hypospray/medipen/healthpen = 4,
+		/obj/item/gun/ballistic/automatic/pistol/makeshift = 2,
+		/obj/item/ammo_box/magazine/makeshift9mm = 2,
+		/obj/item/clothing/head/beret/sec/poland = 1,
+		/obj/item/megaphone = 1,
+	)
+	socio_cost = -20


### PR DESCRIPTION

## About The Pull Request

Adds 3 new cargo buys after you emag the console, which of course comes with all the downsides of 1. having to break into logistics 2. having to have the money and 3. leaving the console 100% traceable with a lasting hack
	name = "Pierogi Delivery"
	desc = "Baked with love by the Polish Liberation Front, unlike those expensive and tasteless Pierogi Rations. Contains x3 Meat Pierogi, x3 Cheese Pierogi."
	name = "Light Resistance Armor"
	desc = "Armor defiantly stolen from the many Civil Protection units and factories both Lambda and the Polish Liberation Front has raided, modified to protect and provide more value then standard CPO vests. Consider this an alternative option should you not be able to source armor on-site, agent. Contains x3 Rebel Light Armor, and as a regional bonus x3 Polish Armbands."
         name = "Bulk Civil Uprising Starter Kit"
	desc = "Start your own revolution today for cheap! No need to buy guns and armor, simply hand these out! *Not responsible for loss of life- promise of free state not guaranteed. Contains x4 Molotov, x2 Lighter, x9 Bricks, x3 Gas Masks, x6 Refugee Suits, x2 Kevlar Vests, x2 Brown Overcoats, x6 Broken Bottles, x4 Healthpens, x2 Makeshift Pistol, x2 Makeshift Pistol Magazine, x1 Polish Liberation Front Beret, x1 Megaphone."

## Why It's Good For The Game

There were none before, effectively making this a waste of an emag charge for breaking into a high security area and waiting 2 minutes for the train to arrive. Now you are rewarded for your crime, and sociostability is deducted for it. Buys are balanced by either being sidegrades or just very general compared to uplink gear (pierogis are a sidegrade to food crate, rebel vests to CPO vests, and the uprising kit is random pieces of trash.)

## Changelog

:cl:
add: emag cargo buys
/:cl:


