### PR TITLE
Emag Train 2 - Black Market Shuttle

### DIFF
--- a/_maps/shuttles/emergency_caravan.dmm
+++ b/_maps/shuttles/emergency_caravan.dmm
@@ -15,6 +15,13 @@
 /obj/structure/shipping_container/vitezstvi/flags,
 /turf/open/floor/plating/indoor/metal/plate,
 /area/shuttle/escape)
+"ba" = (
+/obj/item/hl13_small_flag/poland,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "recruiter"
+	},
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
 "bA" = (
 /obj/structure/chair/sofa/hl13bench{
 	dir = 4
@@ -56,6 +63,7 @@
 /area/shuttle/escape)
 "dJ" = (
 /obj/structure/halflife/trash/wood,
+/obj/machinery/atm,
 /turf/open/floor/plating/indoor/metal/walkway,
 /area/shuttle/escape)
 "eL" = (
@@ -149,6 +157,7 @@
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	id = "recruiter"
 	},
+/obj/machinery/atm,
 /turf/open/floor/plating/indoor/metal/industrial,
 /area/shuttle/escape)
 "rx" = (
@@ -302,10 +311,6 @@
 	},
 /turf/open/floor/plating/indoor/grooved2,
 /area/shuttle/escape)
-"HS" = (
-/obj/structure/chair/office/halflife/red,
-/turf/open/floor/plating/indoor/carpet/green,
-/area/shuttle/escape)
 "Jf" = (
 /obj/machinery/computer/emergency_shuttle{
 	dir = 4
@@ -322,6 +327,10 @@
 	},
 /obj/structure/halflife/trash/wood,
 /turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"KD" = (
+/obj/structure/chair/office/halflife/red,
+/turf/open/floor/plating/indoor/carpet/green,
 /area/shuttle/escape)
 "LE" = (
 /obj/structure/table/halflife/wood,
@@ -549,7 +558,7 @@ jE
 rD
 Pz
 Ae
-qQ
+ba
 FU
 qQ
 Xk
@@ -563,7 +572,7 @@ FU
 (5,1,1) = {"
 FU
 Cy
-HS
+KD
 Ak
 TI
 PO

--- a/_maps/shuttles/emergency_caravan.dmm
+++ b/_maps/shuttles/emergency_caravan.dmm
@@ -1,0 +1,658 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"av" = (
+/obj/machinery/light/directional/east,
+/obj/structure/chair/sofa/hl13bench{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"aF" = (
+/obj/structure/table/halflife/wood,
+/obj/item/storage/halflife/suitcase,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"aS" = (
+/obj/structure/shipping_container/vitezstvi/flags,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"bA" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"bQ" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"cm" = (
+/obj/structure/halflife/trash/glass,
+/obj/structure/chair/sofa/hl13bench{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"cI" = (
+/obj/structure/chair/halflife/metal/stool,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"cO" = (
+/obj/structure/table/halflife/metal/grate,
+/obj/machinery/button/door{
+	name = "recruiter lockdown button";
+	desc = "Used to hide an important trader when the Combine come knocking..";
+	id = "recruiter"
+	},
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"da" = (
+/obj/structure/shipping_container/amsco,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"dm" = (
+/obj/structure/sign/poster/halflife/rebel,
+/turf/closed/wall/halflife/metal/weak/old,
+/area/shuttle/escape)
+"dJ" = (
+/obj/structure/halflife/trash/wood,
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"eL" = (
+/obj/item/table_clock,
+/obj/structure/table/halflife/wood,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"fj" = (
+/obj/structure/halflife/trash/glass/plate,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"gm" = (
+/obj/structure/bed/halflife/bedframe/wire,
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"hI" = (
+/turf/template_noop,
+/area/template_noop)
+"jE" = (
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"kV" = (
+/mob/living/basic/trooper/rebel/mp7/refugee,
+/obj/structure/chair/halflife/metal/folding{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"lL" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"mb" = (
+/obj/structure/sign/poster/halflife/rebel/plf,
+/turf/closed/wall/halflife/metal/weak/old,
+/area/shuttle/escape)
+"mf" = (
+/obj/structure/halflife/trash/wood,
+/obj/machinery/light/directional/east,
+/obj/structure/chair/sofa/hl13bench{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"mq" = (
+/obj/machinery/roulette,
+/obj/structure/halflife/rug/red,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"na" = (
+/obj/structure/table/halflife/no_smooth/large/crafting/tinkerbench,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"oW" = (
+/obj/structure/guncase,
+/obj/item/weaponcrafting/frame/usp,
+/obj/item/ammo_box/magazine/usp9mm,
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"oX" = (
+/obj/structure/table/halflife/no_smooth/large/crafting/weaponbench,
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"pg" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"pn" = (
+/obj/effect/spawner/random/trash/graffiti/halflife/rebelspray,
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"pO" = (
+/obj/structure/halflife/trash/garbage,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"pU" = (
+/obj/structure/halflife/storage/large/shelf,
+/obj/item/stamp/granted,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"pZ" = (
+/obj/machinery/door/unpowered/halflife/seethrough/bar{
+	lockid = "caravan"
+	},
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"qQ" = (
+/obj/item/hl13_small_flag/poland,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "recruiter"
+	},
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"rx" = (
+/obj/machinery/door/unpowered/halflife/seethrough/mirrored/grate{
+	dir = 8;
+	lockid = "caravan"
+	},
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"rD" = (
+/obj/structure/table/halflife/no_smooth/wood,
+/obj/item/poster/halflife/rebel,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"sd" = (
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "recruiter"
+	},
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"sC" = (
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"te" = (
+/obj/structure/table/halflife/no_smooth/dice,
+/obj/item/storage/dice,
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"tg" = (
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"tK" = (
+/obj/structure/halflife/trash/papers/one{
+	desc = "Some scattered papers. Mainly a mess of PLF propaganda and recruitment forms that mean nothing."
+	},
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"uf" = (
+/obj/structure/table/halflife/no_smooth/large/crafting/ammobench,
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"uL" = (
+/obj/structure/dresser,
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"uY" = (
+/obj/structure/shipping_container/great_northern,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"wE" = (
+/obj/structure/closet/crate/halflife{
+	name = "trader footlocker";
+	desc = "A crate containing the trader's belongings that they do not keep on person. A certain caravan manager would probably be mad if you stole from this, but..."
+	},
+/obj/machinery/light/directional/east,
+/obj/item/clothing/under/citizen/refugee/green,
+/obj/item/food/canned/halflife/beans,
+/obj/item/knife/shiv,
+/obj/item/stack/spacecash/c1/ten,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"wZ" = (
+/obj/structure/halflife/trash/papers/two{
+	desc = "Some scattered papers. Mainly a mess of PLF propaganda and recruitment forms that mean nothing."
+	},
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"xi" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"yt" = (
+/obj/item/stamp/denied,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"yE" = (
+/obj/structure/closet/crate/halflife{
+	name = "trader footlocker";
+	desc = "A crate containing the trader's belongings that they do not keep on person. A certain caravan manager would probably be mad if you stole from this, but..."
+	},
+/obj/item/weaponcrafting/receiver,
+/obj/item/stack/sticky_tape,
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"Ae" = (
+/obj/structure/halflife/trash/papers/three,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"Ak" = (
+/obj/structure/table/halflife/wood,
+/obj/item/paper_bin,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Av" = (
+/obj/effect/spawner/random/trash/graffiti/halflife/rebelspray,
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"BW" = (
+/obj/structure/chair/halflife/metal/folding{
+	dir = 1
+	},
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Ca" = (
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Cy" = (
+/obj/structure/closet/cabinet,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/clothing/head/fedora,
+/obj/item/clothing/under/suit/black_really,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/trash/can/food/halflife/beans,
+/obj/item/trash/can/food/halflife/beans,
+/obj/item/trash/can/food/halflife/beans,
+/obj/item/reagent_containers/cup/soda_cans/breenwater/green,
+/obj/item/reagent_containers/cup/soda_cans/breenwater/green,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Fm" = (
+/obj/structure/halflife/storage/shelf,
+/obj/item/clothing/accessory/armband/plf,
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"Fw" = (
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"FU" = (
+/turf/closed/wall/halflife/metal/weak/old,
+/area/shuttle/escape)
+"Ga" = (
+/mob/living/basic/trader/halflife/refugee_tradesmen{
+	desc = "An older looking gentlemen, who looks like they've been in the outlands for a long time before settling down here. They seem to be selling useful supplies."
+	},
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"Gc" = (
+/obj/structure/halflife/trash/garbage/dumpster/crate,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"Gx" = (
+/mob/living/basic/trader/halflife/plf_recruiter{
+	desc = "A represenative of the local PLF cell. They are looking to recruit local caravan guests who wish to fight back against the combine."
+	},
+/turf/open/floor/plating/indoor/grooved2,
+/area/shuttle/escape)
+"HS" = (
+/obj/structure/chair/office/halflife/red,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Jf" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Jv" = (
+/obj/effect/mob_spawn/ghost_role/human/caravan,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Kq" = (
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "recruiter"
+	},
+/obj/structure/halflife/trash/wood,
+/turf/open/floor/plating/indoor/metal/industrial,
+/area/shuttle/escape)
+"LE" = (
+/obj/structure/table/halflife/wood,
+/obj/item/hl2key{
+	lockid = "caravan";
+	name = "caravan management key"
+	},
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Ma" = (
+/obj/structure/closet/crate/halflife{
+	name = "trader footlocker";
+	desc = "A crate containing the trader's belongings that they do not keep on person. A certain caravan manager would probably be mad if you stole from this, but..."
+	},
+/obj/machinery/light/directional/west,
+/obj/item/stack/kevlar/five,
+/obj/item/clothing/under/syndicate/camo/halflife,
+/obj/item/clothing/mask/gas/hl2/military/hardened,
+/obj/item/radio/off/halflife,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"No" = (
+/obj/machinery/door/unpowered/halflife/seethrough/mirrored/grate{
+	dir = 4;
+	lockid = "caravan"
+	},
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"Nx" = (
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	name = "Caravan Transfer Train";
+	preferred_direction = 2;
+	port_direction = 2
+	},
+/turf/closed/wall/halflife/metal/weak/old,
+/area/shuttle/escape)
+"NO" = (
+/obj/structure/chair/halflife/metal/folding{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"Pz" = (
+/obj/structure/closet/mini_fridge/grimy,
+/obj/item/reagent_containers/cup/glass/bottle/beer/light,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"PO" = (
+/obj/structure/chair/halflife/metal/stool,
+/obj/structure/halflife/rug/red,
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"PU" = (
+/obj/structure/table/halflife/no_smooth/large/pool,
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"Qh" = (
+/obj/structure/halflife/trash/garbage/dumpster/crate,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"RZ" = (
+/mob/living/basic/trader/halflife/blackmarket,
+/turf/open/floor/plating/indoor/metal/walkway,
+/area/shuttle/escape)
+"Sg" = (
+/obj/structure/halflife/trash/garbage/dumpster/crate,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"TI" = (
+/turf/open/floor/plating/indoor/carpet/green,
+/area/shuttle/escape)
+"Ue" = (
+/obj/structure/halflife/trash/papers/three,
+/obj/machinery/light/directional/west,
+/obj/structure/chair/sofa/hl13bench{
+	dir = 4
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"VR" = (
+/obj/machinery/door/unpowered/halflife/metal/red{
+	lockid = "caravan"
+	},
+/turf/open/floor/plating/indoor/metal/grate,
+/area/shuttle/escape)
+"Xb" = (
+/obj/structure/chair/sofa/hl13bench{
+	dir = 8
+	},
+/turf/open/floor/plating/indoor/metal/plate,
+/area/shuttle/escape)
+"Xk" = (
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"Xw" = (
+/obj/structure/table/halflife/metal/grate,
+/obj/item/clothing/head/helmet/halflife/military/weak/crafted/poland,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+"YA" = (
+/obj/structure/guncase,
+/obj/item/weaponcrafting/frame/mp7,
+/turf/open/floor/plating/indoor/lino,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+hI
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+rx
+FU
+rx
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+hI
+"}
+(2,1,1) = {"
+FU
+FU
+TI
+TI
+bQ
+mq
+FU
+Sg
+cm
+jE
+Ue
+jE
+xi
+Gc
+da
+NO
+aS
+Gc
+Ma
+pO
+FU
+FU
+FU
+kV
+pg
+bA
+oW
+mb
+FU
+FU
+"}
+(3,1,1) = {"
+FU
+pU
+TI
+aF
+TI
+cI
+FU
+dJ
+Fw
+Fw
+Fw
+Fw
+Fw
+uf
+Fw
+te
+Fw
+RZ
+Fw
+Av
+sd
+pZ
+sd
+tg
+Xk
+tK
+sC
+gm
+FU
+FU
+"}
+(4,1,1) = {"
+Nx
+yt
+Jv
+LE
+BW
+TI
+VR
+jE
+na
+uY
+pO
+fj
+jE
+jE
+jE
+pO
+jE
+rD
+Pz
+Ae
+qQ
+FU
+qQ
+Xk
+Xk
+oX
+sC
+uL
+FU
+FU
+"}
+(5,1,1) = {"
+FU
+Cy
+HS
+Ak
+TI
+PO
+FU
+dJ
+Fw
+Fw
+Ga
+PU
+Fw
+Fw
+Fw
+Fw
+Fw
+Fw
+Fw
+Fw
+Kq
+pZ
+sd
+pn
+wZ
+Xk
+Gx
+yE
+FU
+FU
+"}
+(6,1,1) = {"
+FU
+FU
+Jf
+eL
+lL
+Ca
+FU
+Qh
+jE
+jE
+wE
+jE
+Xb
+Xb
+av
+jE
+Xb
+jE
+mf
+Gc
+FU
+FU
+dm
+Fm
+YA
+Xw
+cO
+FU
+FU
+FU
+"}
+(7,1,1) = {"
+hI
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+No
+FU
+No
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+FU
+hI
+"}

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -118,4 +118,12 @@
 	emag_only = TRUE
 	occupancy_limit = "15"
 
+/datum/map_template/shuttle/emergency/caravan
+	suffix = "caravan"
+	name = "Black Market Caravan Hauler"
+	credit_cost = CARGO_CRATE_VALUE * 12
+	description = "Hello, dear reader. We have received the signal from your hacked communications console and have an active proposition. We anonymous smugglers at the Black Market can offer you a visit from our trade caravan, should you be willing to put down an investment to ensure your city is trustworthy. Just know that no items aboard are free, yes? There will be consequences if harm is done to our tradesmen."
+	emag_only = TRUE
+	occupancy_limit = "15"
+
 #undef EMAG_LOCKED_SHUTTLE_COST

--- a/hl13/code/modules/antagonists/blackmarket.dm
+++ b/hl13/code/modules/antagonists/blackmarket.dm
@@ -28,6 +28,31 @@
 		/obj/item/clothing/mask/gas/hl2/military, //For covertness, if you wish.
 	)
 
+/datum/outfit/caravan_manager // Black Market Agent exclusive to the shuttle
+	name = "Caravan Manager"
+
+	uniform = /obj/item/clothing/under/halflife/blacksuit
+	suit = /obj/item/clothing/suit/jacket/trenchcoat
+	mask = /obj/item/clothing/mask/gas/hl2/oldmask
+	shoes = /obj/item/clothing/shoes/laceup
+	gloves = /obj/item/clothing/gloves/combat
+
+	back = /obj/item/storage/backpack/halflife/satchel
+
+	l_pocket = /obj/item/switchblade
+	r_pocket = /obj/item/market_uplink/halflife/blackmarket
+
+	id = /obj/item/card/id/advanced
+	id_trim = /datum/id_trim/chameleon/blackmarket
+
+	backpack_contents = list(
+		/obj/item/reagent_containers/pill/patch/medkit,
+		/obj/item/reagent_containers/hypospray/medipen/healthpen,
+		/obj/item/ammo_box/magazine/usp9mm,
+		/obj/item/ammo_box/magazine/usp9mm,
+		/obj/item/gun/ballistic/automatic/pistol/usp,
+	)
+
 /datum/outfit/blackmarket_preview
 	name = "Blackmarket dealer (Preview only)"
 

--- a/hl13/code/modules/mob_spawn/mob_spawn.dm
+++ b/hl13/code/modules/mob_spawn/mob_spawn.dm
@@ -54,3 +54,15 @@
 	. = ..()
 	if(prob(50)) //only has a 25% chance of existing
 		return INITIALIZE_HINT_QDEL
+
+/obj/effect/mob_spawn/ghost_role/human/caravan
+	name = "sensory deprivation pod"
+	desc = "A luxury sensory deprivation pod. Someone appears to be sleeping in it to de-stress from all the chaos of smuggler life... forcing them out seems bound for nothing but chaos, guess you can only hope they get out soon."
+	density = FALSE
+	you_are_text = "You are an agent of the Black Market, managing a caravan and its traders."
+	flavour_text = "You were called using a hacked combine communications console, and offered a sum of credits to bring over a group of traders. You have no care to who boards your train, as long as they're a paying customer- just try to keep any combine away from the PLF recruiter in the back of the train. Earn money via selling items with your uplink and ensure nothing is stolen from your traders, or worse, any are killed."
+	important_text = "You are not openly friendly nor hostile to any rebel group or even the combine, save for fellow Black Market agents. Additionally, do not abandon the train (and if the train has not launched maybe you shouldn't have picked this role, just try and wait)."
+	icon = 'icons/obj/mining_zones/spawners.dmi'
+	icon_state = "terrarium"
+	spawner_job_path = /datum/antagonist/blackmarket
+	outfit = /datum/outfit/caravan_manager


### PR DESCRIPTION
## About The Pull Request
 Adds more shuttle representation so you have more reason to emag the comms console. Also gives 3 of the standard traitor factions their own train-buy: Lambda, PLF, and now Black Market Agent.
 
 
<img width="216" height="952" alt="image" src="https://github.com/user-attachments/assets/da7babaf-f9c5-4b34-9ee2-95ecbdc541e7" />

## Why It's Good For The Game

This is much cheaper then the other emag trains but more PERSONALLY expensive (have to spend credits) and risk based (free agent antag + npcs that can become hostile) then the standard trains. Instead of getting free weaponry and gear like the other emag trains, you instead have to bring your own credits to buy weaponry, and you lack an armored position / comfort. Alongside that, a neutral agent black market caravan dealer spawns as a ghost role aboard this train, which can be viewed as both a benefit and negative as they will stop you from stealing from the footlockers of the trader (the only way to get loot for free) but also break up any conflict between you, the combine, or the traders. 

## Changelog

:cl:
add: black market caravan train
/:cl:

