### PR TITLE
New traitor employers

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -320,7 +320,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 /// The normal cost of an uplink implant; used for calcuating how many
 /// TC to charge someone if they get a free implant through choice or
 /// because they have nothing else that supports an implant.
-#define UPLINK_IMPLANT_TELECRYSTAL_COST 4
+#define UPLINK_IMPLANT_TELECRYSTAL_COST 0
 
 /// Items with this stock key do not share stock with other items
 #define UPLINK_SHARED_STOCK_UNIQUE "uplink_shared_stock_unique"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -166,6 +166,8 @@ GLOBAL_LIST_INIT(syndicate_employers, list(
 	"Lambda",
 	"Black Market Agent",
 	"Refugee Spy",
+	"United Nations Remnant",
+	"Radicalized",
 ))
 ///employers that are from Nanotrasen
 GLOBAL_LIST_INIT(nanotrasen_employers, list(
@@ -175,6 +177,7 @@ GLOBAL_LIST_INIT(nanotrasen_employers, list(
 ///employers who hire agents to do the hijack
 GLOBAL_LIST_INIT(hijack_employers, list(
 	"Lambda",
+	"United Nations Remnant",
 ))
 
 ///employers who hire agents to do a task and escape... or martyrdom. whatever
@@ -182,6 +185,7 @@ GLOBAL_LIST_INIT(normal_employers, list(
 	"Black Market Agent",
 	"Refugee Spy",
 	"Internal Affairs Agent",
+	"Radicalized",
 ))
 
 ///employers for malfunctioning ais. they do not have sides, unlike traitors.
@@ -316,7 +320,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 /// The normal cost of an uplink implant; used for calcuating how many
 /// TC to charge someone if they get a free implant through choice or
 /// because they have nothing else that supports an implant.
-#define UPLINK_IMPLANT_TELECRYSTAL_COST 0
+#define UPLINK_IMPLANT_TELECRYSTAL_COST 4
 
 /// Items with this stock key do not share stock with other items
 #define UPLINK_SHARED_STOCK_UNIQUE "uplink_shared_stock_unique"

--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -39,6 +39,22 @@
 		"ui_theme": "syndicate",
 		"uplink": "For the sake of plausible deniability, you have been equipped with an array of captured Lambda weaponry available via uplink."
 	},
+	"United Nations Remnant": {
+		"allies": "You work to unite the soldiers and civilians who still remember the name of peace!",
+		"goal": "You work to reform a peace long twisted by the Combine and bring it back to its original form, even if you are scarred fighting for it.",
+		"introduction": "You are the United Nations Remnant.",
+		"roundend_report": "was a United Nations remnant.",
+		"ui_theme": "syndicate",
+		"uplink": "After weeks of bartering on the Black Market, Lambda has granted you an uplink."
+	},
+	"Radicalized": {
+		"allies": "You dream to work alongside a real rebel, but others who share your view would do just fine...",
+		"goal": "Through the many propaganda posters or recent riots in your city, you have opened your previously blind eyes to the rebels fighting for freedom from the Combine. You are determined to help even if they do not know of you, and maybe even find a way to join through your efforts!",
+		"introduction": "You are Radicalized.",
+		"roundend_report": "was a radicalized citizen.",
+		"ui_theme": "syndicate",
+		"uplink": "Through studying hidden messages in information campaign posters, you managed to piece together an uplink to connect with Lambda."
+	},
 	"Contractor Support Unit": {
 		"allies": "You are being sent to help your designated agent. Their allegiences are above all others.",
 		"goal": "Help your designated agent to the furtest extent you can, their life is above your own.",


### PR DESCRIPTION

## About The Pull Request

Adds 2 new traitor employers, the United Nations Remnant and the Radicalized Citizen. UN Remnant is a hijack employer, and Radicalized is a standard traitor.

## Why It's Good For The Game

More world building, + these are just gameplay suggestions and aren't forced (flavor only)

## Changelog



:cl:
add: UN Remnant + Radicalized Traitor Employers
/:cl: